### PR TITLE
Set Max Limit on number of executors to be launched in spark plugin

### DIFF
--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -31,6 +31,8 @@ import (
 const KindSparkApplication = "SparkApplication"
 const sparkDriverUI = "sparkDriverUI"
 const sparkHistoryUI = "sparkHistoryUI"
+const sparkExecutorKey = "spark.executor.instances"
+const sparkExecutorLimitKey = "spark.executor.instances.limit"
 
 var sparkTaskType = "spark"
 
@@ -81,8 +83,8 @@ func min(a, b int) int {
 
 func populateSparkConfig(sparkConfig, userSparkConfig map[string]string) error {
 	for k, v := range userSparkConfig {
-		if k == "spark.executor.instances" && sparkConfig["spark.executor.instances"] != "" {
-			limit, err := strconv.Atoi(sparkConfig["spark.executor.instances"])
+		if k == sparkExecutorKey && sparkConfig[sparkExecutorLimitKey] != "" {
+			limit, err := strconv.Atoi(sparkConfig[sparkExecutorLimitKey])
 			if err != nil {
 				return err
 			}

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -44,7 +44,7 @@ type Config struct {
 
 // Spark Limits config
 type Limits struct {
-	ExecutorLimit string `json:"executor-limit" pflag:",Max limit on number of executors allowed to be launched."`
+	ExecutorCountLimit string `json:"executor-count-limit" pflag:",Max limit on number of executors allowed to be launched."`
 }
 
 var (
@@ -88,12 +88,12 @@ func min(a, b int) int {
 
 func checkLimits(sparkConfig map[string]string, limits Limits) error {
 	// Enforce executor limits
-	if limits.ExecutorLimit != "" {
+	if limits.ExecutorCountLimit != "" {
 		userRequest, err := strconv.Atoi(sparkConfig[sparkExecutorKey])
 		if err != nil {
 			return err
 		}
-		limit, err := strconv.Atoi(limits.ExecutorLimit)
+		limit, err := strconv.Atoi(limits.ExecutorCountLimit)
 		if err != nil {
 			return err
 		}

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -32,7 +32,6 @@ const KindSparkApplication = "SparkApplication"
 const sparkDriverUI = "sparkDriverUI"
 const sparkHistoryUI = "sparkHistoryUI"
 const sparkExecutorKey = "spark.executor.instances"
-const sparkExecutorLimitKey = "spark.executor.instances.limit"
 
 var sparkTaskType = "spark"
 

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -310,12 +310,12 @@ func TestPopulateSparkConfigExecutorLimit(t *testing.T) {
 	}{
 		{
 			"User executor config less than limit",
-			map[string]string{"spark.executor.instances": "5"},
+			map[string]string{sparkExecutorLimitKey: "5"},
 			"3",
 		},
 		{
 			"User executor config greater than limit",
-			map[string]string{"spark.executor.instances": "1"},
+			map[string]string{sparkExecutorLimitKey: "1"},
 			"1",
 		},
 		{
@@ -327,7 +327,7 @@ func TestPopulateSparkConfigExecutorLimit(t *testing.T) {
 
 	for _, tc := range testCases {
 		_ = populateSparkConfig(tc.sparkConfig, dummySparkConf)
-		got := tc.sparkConfig["spark.executor.instances"]
+		got := tc.sparkConfig[sparkExecutorKey]
 		if got != tc.want {
 			t.Errorf("Test Case: %s, got %s, want %s", tc.description, got, tc.want)
 		}

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -304,29 +304,33 @@ func TestBuildResourceSpark(t *testing.T) {
 
 func TestPopulateSparkConfigExecutorLimit(t *testing.T) {
 	testCases := []struct {
-		description string
-		sparkConfig map[string]string
-		want        string
+		description  string
+		limitsConfig Limits
+		sparkConfig  map[string]string
+		want         string
 	}{
 		{
 			"User executor config less than limit",
-			map[string]string{sparkExecutorLimitKey: "5"},
+			Limits{ExecutorLimit: "3"},
+			map[string]string{sparkExecutorKey: "5"},
 			"3",
 		},
 		{
 			"User executor config greater than limit",
-			map[string]string{sparkExecutorLimitKey: "1"},
+			Limits{ExecutorLimit: "1"},
+			map[string]string{sparkExecutorKey: "3"},
 			"1",
 		},
 		{
 			"No limit set.",
-			map[string]string{},
+			Limits{},
+			map[string]string{sparkExecutorKey: "3"},
 			"3",
 		},
 	}
 
 	for _, tc := range testCases {
-		_ = populateSparkConfig(tc.sparkConfig, dummySparkConf)
+		_ = checkLimits(tc.sparkConfig, tc.limitsConfig)
 		got := tc.sparkConfig[sparkExecutorKey]
 		if got != tc.want {
 			t.Errorf("Test Case: %s, got %s, want %s", tc.description, got, tc.want)

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -302,7 +302,7 @@ func TestBuildResourceSpark(t *testing.T) {
 	assert.Nil(t, resource)
 }
 
-func TestPopulateSparkConfigExecutorLimit(t *testing.T) {
+func TestPopulateSparkConfigExecutorCountLimit(t *testing.T) {
 	testCases := []struct {
 		description  string
 		limitsConfig Limits
@@ -311,13 +311,13 @@ func TestPopulateSparkConfigExecutorLimit(t *testing.T) {
 	}{
 		{
 			"User executor config less than limit",
-			Limits{ExecutorLimit: "3"},
+			Limits{ExecutorCountLimit: "3"},
 			map[string]string{sparkExecutorKey: "5"},
 			"3",
 		},
 		{
 			"User executor config greater than limit",
-			Limits{ExecutorLimit: "1"},
+			Limits{ExecutorCountLimit: "1"},
 			map[string]string{sparkExecutorKey: "3"},
 			"1",
 		},

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -301,3 +301,35 @@ func TestBuildResourceSpark(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Nil(t, resource)
 }
+
+func TestPopulateSparkConfigExecutorLimit(t *testing.T) {
+	testCases := []struct {
+		description string
+		sparkConfig map[string]string
+		want        string
+	}{
+		{
+			"User executor config less than limit",
+			map[string]string{"spark.executor.instances": "5"},
+			"3",
+		},
+		{
+			"User executor config greater than limit",
+			map[string]string{"spark.executor.instances": "1"},
+			"1",
+		},
+		{
+			"No limit set.",
+			map[string]string{},
+			"3",
+		},
+	}
+
+	for _, tc := range testCases {
+		_ = populateSparkConfig(tc.sparkConfig, dummySparkConf)
+		got := tc.sparkConfig["spark.executor.instances"]
+		if got != tc.want {
+			t.Errorf("Test Case: %s, got %s, want %s", tc.description, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
# TL;DR
Allows configuration to set a max limit on spark executor by specifying `spark.executor.instances:<max_limit>` as part of the default spark configuration.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/366

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
