### PR TITLE
Mark items from workqueue as Done()

### DIFF
--- a/go/tasks/pluginmachinery/workqueue/queue.go
+++ b/go/tasks/pluginmachinery/workqueue/queue.go
@@ -208,6 +208,10 @@ func (q *queue) Start(ctx context.Context) error {
 						logger.Debug(ctx, "Work queue is shutting down.")
 						return
 					}
+					
+					// Mark the item as done processing. The logic below will determine whether it should go back into the queue
+					// (behind everything else) or whether it requires no further processing.
+					q.queue.Done(item)
 
 					wrapperV := item.(*workItemWrapper).Clone()
 					wrapper := &wrapperV

--- a/go/tasks/pluginmachinery/workqueue/queue.go
+++ b/go/tasks/pluginmachinery/workqueue/queue.go
@@ -208,7 +208,7 @@ func (q *queue) Start(ctx context.Context) error {
 						logger.Debug(ctx, "Work queue is shutting down.")
 						return
 					}
-					
+
 					wrapperV := item.(*workItemWrapper).Clone()
 					wrapper := &wrapperV
 					ws := wrapper.status
@@ -221,34 +221,34 @@ func (q *queue) Start(ctx context.Context) error {
 								err = e
 							}
 
-                 					// Mark the item as done processing. The logic below will determine whether it should go back into the queue
-		                   			// (behind everything else) or whether it requires no further processing.
-				                     	q.queue.Done(item)
+							// Mark the item as done processing. The logic below will determine whether it should go back into the queue
+							// (behind everything else) or whether it requires no further processing.
+							q.queue.Done(item)
 						}()
 
 						ctxWithFields := contextWithValues(ctx, wrapper.logFields)
 						ws, err = q.processor.Process(ctxWithFields, wrapper.payload)
 
-             					if err != nil {
-		           				q.metrics.ProcessorErrors.Inc()
+						if err != nil {
+							q.metrics.ProcessorErrors.Inc()
 
-			        			wrapper.retryCount++
-				        		wrapper.err = err
-					         	if wrapper.retryCount >= uint(q.maxRetries) {
-						          	logger.Debugf(ctx, "WorkItem [%v] exhausted all retries. Last Error: %v.",
-							          	wrapper.ID(), err)
-          							wrapper.status = WorkStatusFailed
-	           						ws = WorkStatusFailed
-		              					q.index.Add(wrapper)							
-				              			return
-						        }
-        					}
+							wrapper.retryCount++
+							wrapper.err = err
+							if wrapper.retryCount >= uint(q.maxRetries) {
+								logger.Debugf(ctx, "WorkItem [%v] exhausted all retries. Last Error: %v.",
+									wrapper.ID(), err)
+								wrapper.status = WorkStatusFailed
+								ws = WorkStatusFailed
+								q.index.Add(wrapper)
+								return
+							}
+						}
 
-         					wrapper.status = ws
-         					q.index.Add(wrapper)
-          					if !ws.IsTerminal() {
-              						q.queue.Add(wrapper)
-          					}
+						wrapper.status = ws
+						q.index.Add(wrapper)
+						if !ws.IsTerminal() {
+							q.queue.Add(wrapper)
+						}
 					}()
 				}
 			}


### PR DESCRIPTION
# TL;DR
Item processor queue used to process catalog items and outputs coalescing for arrays has a bug where it doesn't mark items as done when it finishes processing. This leads to the items being processed again and again wasting resources, clogging the queue and flooding external services with unnecessary requests.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Tracking Issue
https://github.com/lyft/flyte/issues/587