### PR TITLE
Fix log links in K8s Array tasks

### DIFF
--- a/copilot/go.mod
+++ b/copilot/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/protobuf v1.4.2
 	github.com/imdario/mergo v0.3.9 // indirect
-	github.com/lyft/flyteidl v0.18.0
+	github.com/lyft/flyteidl v0.18.9
 	github.com/lyft/flyteplugins v0.4.4
 	github.com/lyft/flytestdlib v0.3.9
 	github.com/mitchellh/go-ps v1.0.0

--- a/copilot/go.sum
+++ b/copilot/go.sum
@@ -377,6 +377,7 @@ github.com/lyft/flyteidl v0.17.32 h1:Iio3gYjTyPhAiOMWJ/H/4YtfWIZm5KZSlWMULT1Ef6U
 github.com/lyft/flyteidl v0.17.32/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteidl v0.18.0 h1:f4yv1MafE26wpMC6QlthM02EeTEDXpy/waL54dRDiSs=
 github.com/lyft/flyteidl v0.18.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
+github.com/lyft/flyteidl v0.18.9/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flytepropeller v0.3.6/go.mod h1:1Iw3ngmJBP+52coloHL1rOxcX7EDDUUvTYFQQy2WYzk=
 github.com/lyft/flytestdlib v0.3.0/go.mod h1:LJPPJlkFj+wwVWMrQT3K5JZgNhZi2mULsCG4ZYhinhU=
 github.com/lyft/flytestdlib v0.3.9 h1:NaKp9xkeWWwhVvqTOcR/FqlASy1N2gu/kN7PVe4S7YI=

--- a/go.sum
+++ b/go.sum
@@ -395,6 +395,7 @@ github.com/lyft/flytestdlib v0.3.3 h1:MkWXPkwQinh6MR3Yf5siZhmRSt9r4YmsF+5kvVVVed
 github.com/lyft/flytestdlib v0.3.3/go.mod h1:LJPPJlkFj+wwVWMrQT3K5JZgNhZi2mULsCG4ZYhinhU=
 github.com/lyft/flytestdlib v0.3.9 h1:NaKp9xkeWWwhVvqTOcR/FqlASy1N2gu/kN7PVe4S7YI=
 github.com/lyft/flytestdlib v0.3.9/go.mod h1:LJPPJlkFj+wwVWMrQT3K5JZgNhZi2mULsCG4ZYhinhU=
+github.com/lyft/spark-on-k8s-operator v0.1.4-0.20201027003055-c76b67e3b6d0 h1:1vSmc+Bo70X0JVYywQ9Hy/aet6p613ejacy9x5td0m4=
 github.com/lyft/spark-on-k8s-operator v0.1.4-0.20201027003055-c76b67e3b6d0/go.mod h1:hkRqdqAsdNnxT/Zst6MNMRbTAoiCZ0JRw7svRgAYb0A=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=

--- a/go/tasks/logs/logging_utils.go
+++ b/go/tasks/logs/logging_utils.go
@@ -9,13 +9,15 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-func GetLogsForContainerInPod(ctx context.Context, pod *v1.Pod, index uint32, nameSuffix string) ([]*core.TaskLog, error) {
+func GetLogsForContainerInPodCustomURL(ctx context.Context, pod *v1.Pod, index uint32, nameSuffix, kubernetesURL string) ([]*core.TaskLog, error) {
 	var logs []*core.TaskLog
 	logConfig := GetLogConfig()
 
 	logPlugins := map[string]logUtils.LogPlugin{}
 
-	if logConfig.IsKubernetesEnabled {
+	if kubernetesURL != "" {
+		logPlugins["Kubernetes Logs"] = logUtils.NewKubernetesLogPlugin(kubernetesURL)
+	} else if logConfig.IsKubernetesEnabled {
 		logPlugins["Kubernetes Logs"] = logUtils.NewKubernetesLogPlugin(logConfig.KubernetesURL)
 	}
 	if logConfig.IsCloudwatchEnabled {
@@ -58,4 +60,7 @@ func GetLogsForContainerInPod(ctx context.Context, pod *v1.Pod, index uint32, na
 		logs = append(logs, &log)
 	}
 	return logs, nil
+}
+func GetLogsForContainerInPod(ctx context.Context, pod *v1.Pod, index uint32, nameSuffix string) ([]*core.TaskLog, error) {
+	return GetLogsForContainerInPodCustomURL(ctx, pod, index, nameSuffix, "")
 }

--- a/go/tasks/plugins/array/k8s/config.go
+++ b/go/tasks/plugins/array/k8s/config.go
@@ -46,10 +46,11 @@ type ResourceConfig struct {
 }
 
 type ClusterConfig struct {
-	Name     string `json:"name" pflag:",Friendly name of the remote cluster"`
-	Endpoint string `json:"endpoint" pflag:", Remote K8s cluster endpoint"`
-	Auth     Auth   `json:"auth" pflag:"-, Auth setting for the cluster"`
-	Enabled  bool   `json:"enabled" pflag:", Boolean flag to enable or disable"`
+	Name          string `json:"name" pflag:",Friendly name of the remote cluster"`
+	Endpoint      string `json:"endpoint" pflag:", Remote K8s cluster endpoint"`
+	Auth          Auth   `json:"auth" pflag:"-, Auth setting for the cluster"`
+	KubernetesURL string `json:"kubernetes-url" pflag:",Console URL for Kubernetes logs"`
+	Enabled       bool   `json:"enabled" pflag:", Boolean flag to enable or disable"`
 }
 
 type Auth struct {

--- a/go/tasks/plugins/array/k8s/monitor_test.go
+++ b/go/tasks/plugins/array/k8s/monitor_test.go
@@ -189,7 +189,6 @@ func TestCheckSubTasksStateResourceGranted(t *testing.T) {
 		}
 		for childIdx := range arrayStatus.Detailed.GetItems() {
 			arrayStatus.Detailed.SetItem(childIdx, bitarray.Item(core.PhaseSuccess))
-
 		}
 		newState, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", &arrayCore.State{
 			CurrentPhase:         arrayCore.PhaseCheckingSubTaskExecutions,


### PR DESCRIPTION
Currently Log links are not sent to Admin/UI for K8s batch array task due to a bug. Similarly there were other cases that were breaking.

* Log links for remote cluster execution.
* Log links for finished tasks
* Introduces finalizer for pods created by K8s array task.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

PTAL @EngHabu @katrogan 