### PR TITLE
Add support for custom KubeClient

### DIFF
--- a/go/tasks/pluginmachinery/k8s/plugin.go
+++ b/go/tasks/pluginmachinery/k8s/plugin.go
@@ -32,6 +32,14 @@ type PluginEntry struct {
 	// support the same task type. This must be a subset of RegisteredTaskTypes and at most one default per task type
 	// is supported.
 	DefaultForTaskTypes []pluginsCore.TaskType
+	// Returns a new KubeClient to be used instead of the internal controller-runtime client.
+	NewKubeClient func(ctx context.Context) (pluginsCore.KubeClient, error)
+	// Boolean that indicates if kubernetes resources that this plugin is responsible for should include OwnerReferences.
+	// Ingoring is only useful if resources will be created in a remote cluster.
+	OverrideInjectOwnerReferences *bool
+	// Boolean flag that indicates if a finalizer should be injected.
+	// This will override the `inject-finalizer` set under k8s config.
+	OverrideInjectFinalizer *bool
 }
 
 // Special context passed in to plugins when checking task phase

--- a/go/tasks/pluginmachinery/k8s/plugin.go
+++ b/go/tasks/pluginmachinery/k8s/plugin.go
@@ -33,7 +33,7 @@ type PluginEntry struct {
 	// is supported.
 	DefaultForTaskTypes []pluginsCore.TaskType
 	// Returns a new KubeClient to be used instead of the internal controller-runtime client.
-	NewKubeClient func(ctx context.Context) (pluginsCore.KubeClient, error)
+	CustomKubeClient func(ctx context.Context) (pluginsCore.KubeClient, error)
 	// Boolean that indicates if kubernetes resources that this plugin is responsible for should include OwnerReferences.
 	// Ingoring is only useful if resources will be created in a remote cluster.
 	OverrideInjectOwnerReferences *bool


### PR DESCRIPTION
Allow supplying a custom KubeClient to `PluginManager`. When supplied `PluginManager` should use this client instead of the internal one.

By supplying a custom `KubeClient` we are able to create a client to a remote cluster.


## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue
