### PR TITLE
Fix for setting task info OccurredAt when not set.

### DIFF
--- a/go/tasks/pluginmachinery/core/phase.go
+++ b/go/tasks/pluginmachinery/core/phase.go
@@ -131,6 +131,9 @@ var PhaseInfoUndefined = PhaseInfo{phase: PhaseUndefined}
 
 func phaseInfo(p Phase, v uint32, err *core.ExecutionError, info *TaskInfo) PhaseInfo {
 	if info == nil {
+		info = &TaskInfo{}
+	}
+	if info.OccurredAt == nil {
 		t := time.Now()
 		info = &TaskInfo{
 			OccurredAt: &t,

--- a/go/tasks/pluginmachinery/core/phase.go
+++ b/go/tasks/pluginmachinery/core/phase.go
@@ -135,9 +135,7 @@ func phaseInfo(p Phase, v uint32, err *core.ExecutionError, info *TaskInfo) Phas
 	}
 	if info.OccurredAt == nil {
 		t := time.Now()
-		info = &TaskInfo{
-			OccurredAt: &t,
-		}
+		info.OccurredAt = &t
 	}
 	return PhaseInfo{
 		phase:   p,


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Fix for setting phase info OccurredAt when not set.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
