### PR TITLE
[K8s Array] Fix ResourceQuota usage + logs for partially running jobs

### DIFF
--- a/go/tasks/pluginmachinery/core/mocks/fake_k8s_cache.go
+++ b/go/tasks/pluginmachinery/core/mocks/fake_k8s_cache.go
@@ -1,0 +1,173 @@
+package mocks
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type FakeKubeCache struct {
+	syncObj sync.RWMutex
+	Cache   map[string]runtime.Object
+}
+
+func (m *FakeKubeCache) GetInformer(ctx context.Context, obj client.Object) (cache.Informer, error) {
+	panic("implement me")
+}
+
+func (m *FakeKubeCache) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (cache.Informer, error) {
+	panic("implement me")
+}
+
+func (m *FakeKubeCache) Start(ctx context.Context) error {
+	panic("implement me")
+}
+
+func (m *FakeKubeCache) WaitForCacheSync(ctx context.Context) bool {
+	panic("implement me")
+}
+
+func (m *FakeKubeCache) IndexField(ctx context.Context, obj client.Object, field string, extractValue client.IndexerFunc) error {
+	panic("implement me")
+}
+
+func (m *FakeKubeCache) Get(ctx context.Context, key client.ObjectKey, out client.Object) error {
+	m.syncObj.RLock()
+	defer m.syncObj.RUnlock()
+
+	item, found := m.Cache[formatKey(key, out.GetObjectKind().GroupVersionKind())]
+	if found {
+		// deep copy to avoid mutating cache
+		item = item.(runtime.Object).DeepCopyObject()
+		_, isUnstructured := out.(*unstructured.Unstructured)
+		if isUnstructured {
+			// Copy the value of the item in the cache to the returned value
+			outVal := reflect.ValueOf(out)
+			objVal := reflect.ValueOf(item)
+			if !objVal.Type().AssignableTo(outVal.Type()) {
+				return fmt.Errorf("cache had type %s, but %s was asked for", objVal.Type(), outVal.Type())
+			}
+			reflect.Indirect(outVal).Set(reflect.Indirect(objVal))
+			return nil
+		}
+
+		p, err := runtime.DefaultUnstructuredConverter.ToUnstructured(item)
+		if err != nil {
+			return err
+		}
+
+		return runtime.DefaultUnstructuredConverter.FromUnstructured(p, out)
+	}
+
+	return errors.NewNotFound(schema.GroupResource{}, key.Name)
+}
+
+func (m *FakeKubeCache) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	m.syncObj.RLock()
+	defer m.syncObj.RUnlock()
+
+	objs := make([]runtime.Object, 0, len(m.Cache))
+
+	listOptions := &client.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(listOptions)
+	}
+
+	for _, val := range m.Cache {
+		if listOptions.Raw != nil {
+			if val.GetObjectKind().GroupVersionKind().Kind != listOptions.Raw.Kind {
+				continue
+			}
+
+			if val.GetObjectKind().GroupVersionKind().GroupVersion().String() != listOptions.Raw.APIVersion {
+				continue
+			}
+		}
+
+		objs = append(objs, val.(runtime.Object).DeepCopyObject())
+	}
+
+	return meta.SetList(list, objs)
+}
+
+func (m *FakeKubeCache) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) (err error) {
+	m.syncObj.Lock()
+	defer m.syncObj.Unlock()
+
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	key := formatKey(types.NamespacedName{
+		Name:      accessor.GetName(),
+		Namespace: accessor.GetNamespace(),
+	}, obj.GetObjectKind().GroupVersionKind())
+
+	if _, exists := m.Cache[key]; !exists {
+		m.Cache[key] = obj
+		return nil
+	}
+
+	return errors.NewAlreadyExists(schema.GroupResource{}, accessor.GetName())
+}
+
+func (m *FakeKubeCache) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	m.syncObj.Lock()
+	defer m.syncObj.Unlock()
+
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	key := formatKey(types.NamespacedName{
+		Name:      accessor.GetName(),
+		Namespace: accessor.GetNamespace(),
+	}, obj.GetObjectKind().GroupVersionKind())
+
+	delete(m.Cache, key)
+
+	return nil
+}
+
+func (m *FakeKubeCache) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	m.syncObj.Lock()
+	defer m.syncObj.Unlock()
+
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	key := formatKey(types.NamespacedName{
+		Name:      accessor.GetName(),
+		Namespace: accessor.GetNamespace(),
+	}, obj.GetObjectKind().GroupVersionKind())
+
+	if _, exists := m.Cache[key]; exists {
+		m.Cache[key] = obj
+		return nil
+	}
+
+	return errors.NewNotFound(schema.GroupResource{}, accessor.GetName())
+}
+
+func NewFakeKubeCache() *FakeKubeCache {
+	return &FakeKubeCache{
+		syncObj: sync.RWMutex{},
+		Cache:   map[string]runtime.Object{},
+	}
+}

--- a/go/tasks/pluginmachinery/core/phase.go
+++ b/go/tasks/pluginmachinery/core/phase.go
@@ -159,6 +159,12 @@ func PhaseInfoWaitingForResources(t time.Time, version uint32, reason string) Ph
 	return pi
 }
 
+func PhaseInfoWaitingForResourcesInfo(t time.Time, version uint32, reason string, info *TaskInfo) PhaseInfo {
+	pi := phaseInfo(PhaseWaitingForResources, version, nil, info)
+	pi.reason = reason
+	return pi
+}
+
 func PhaseInfoQueued(t time.Time, version uint32, reason string) PhaseInfo {
 	pi := phaseInfo(PhaseQueued, version, nil, &TaskInfo{OccurredAt: &t})
 	pi.reason = reason

--- a/go/tasks/pluginmachinery/core/phase.go
+++ b/go/tasks/pluginmachinery/core/phase.go
@@ -152,13 +152,14 @@ func PhaseInfoNotReady(t time.Time, version uint32, reason string) PhaseInfo {
 	return pi
 }
 
-// Return in the case the plugin is not ready to start
+// Deprecated: Please use PhaseInfoWaitingForResourcesInfo instead
 func PhaseInfoWaitingForResources(t time.Time, version uint32, reason string) PhaseInfo {
 	pi := phaseInfo(PhaseWaitingForResources, version, nil, &TaskInfo{OccurredAt: &t})
 	pi.reason = reason
 	return pi
 }
 
+// Return in the case the plugin is not ready to start
 func PhaseInfoWaitingForResourcesInfo(t time.Time, version uint32, reason string, info *TaskInfo) PhaseInfo {
 	pi := phaseInfo(PhaseWaitingForResources, version, nil, info)
 	pi.reason = reason

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -200,7 +200,7 @@ func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idl
 		phaseInfo = core.PhaseInfoRunning(version, nowTaskInfo)
 
 	case PhaseWaitingForResources:
-		phaseInfo = core.PhaseInfoWaitingForResources(t, version, state.GetReason())
+		phaseInfo = core.PhaseInfoWaitingForResourcesInfo(t, version, state.GetReason(), nowTaskInfo)
 
 	case PhaseCheckingSubTaskExecutions:
 		// For future Running core.Phases, we have to make sure we don't use an earlier Admin version number,

--- a/go/tasks/plugins/array/k8s/integration_test.go
+++ b/go/tasks/plugins/array/k8s/integration_test.go
@@ -37,6 +37,7 @@ func init() {
 func newMockExecutor(ctx context.Context, t testing.TB) (Executor, array.AdvanceIteration) {
 	kubeClient := &mocks.KubeClient{}
 	kubeClient.OnGetClient().Return(mocks.NewFakeKubeClient())
+	kubeClient.OnGetCache().Return(mocks.NewFakeKubeCache())
 	e, err := NewExecutor(kubeClient, &Config{
 		MaxErrorStringLength: 200,
 		OutputAssembler: workqueue.Config{

--- a/go/tasks/plugins/array/k8s/monitor_test.go
+++ b/go/tasks/plugins/array/k8s/monitor_test.go
@@ -264,12 +264,14 @@ func TestCheckSubTasksStateResourceGranted(t *testing.T) {
 			arrayStatus.Detailed.SetItem(childIdx, bitarray.Item(core.PhaseSuccess))
 
 		}
+		cacheIndexes := bitarray.NewBitSet(5)
 		newState, _, subTaskIDs, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", &arrayCore.State{
 			CurrentPhase:         arrayCore.PhaseCheckingSubTaskExecutions,
 			ExecutionArraySize:   5,
 			OriginalArraySize:    10,
 			OriginalMinSuccesses: 5,
 			ArrayStatus:          *arrayStatus,
+			IndexesToCache:       cacheIndexes,
 		})
 
 		assert.Nil(t, err)

--- a/go/tasks/plugins/array/k8s/monitor_test.go
+++ b/go/tasks/plugins/array/k8s/monitor_test.go
@@ -121,6 +121,8 @@ func TestCheckSubTasksState(t *testing.T) {
 	tCtx := getMockTaskExecutionContext(ctx)
 	kubeClient := mocks.KubeClient{}
 	kubeClient.OnGetClient().Return(mocks.NewFakeKubeClient())
+	kubeClient.OnGetCache().Return(mocks.NewFakeKubeCache())
+
 	resourceManager := mocks.ResourceManager{}
 	resourceManager.OnAllocateResourceMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(core.AllocationStatusExhausted, nil)
 	tCtx.OnResourceManager().Return(&resourceManager)
@@ -213,6 +215,8 @@ func TestCheckSubTasksStateResourceGranted(t *testing.T) {
 	tCtx := getMockTaskExecutionContext(ctx)
 	kubeClient := mocks.KubeClient{}
 	kubeClient.OnGetClient().Return(mocks.NewFakeKubeClient())
+	kubeClient.OnGetCache().Return(mocks.NewFakeKubeCache())
+
 	resourceManager := mocks.ResourceManager{}
 
 	resourceManager.OnAllocateResourceMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(core.AllocationStatusGranted, nil)

--- a/go/tasks/plugins/array/k8s/task.go
+++ b/go/tasks/plugins/array/k8s/task.go
@@ -113,7 +113,7 @@ func (t Task) Launch(ctx context.Context, tCtx core.TaskExecutionContext, kubeCl
 
 	// Check for existing pods to prevent unnecessary Resource-Quota usage: https://github.com/kubernetes/kubernetes/issues/76787
 	existingPod := &corev1.Pod{}
-	err = kubeClient.GetClient().Get(context.Background(), client.ObjectKey{
+	err = kubeClient.GetCache().Get(context.Background(), client.ObjectKey{
 		Namespace: pod.GetNamespace(),
 		Name:      pod.GetName(),
 	}, existingPod)

--- a/go/tasks/plugins/array/k8s/task.go
+++ b/go/tasks/plugins/array/k8s/task.go
@@ -2,7 +2,6 @@ package k8s
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -142,9 +141,6 @@ func (t Task) Launch(ctx context.Context, tCtx core.TaskExecutionContext, kubeCl
 		// Another error returned.
 		logger.Error(ctx, err)
 		return LaunchError, errors2.Wrapf(ErrSubmitJob, err, "Failed to submit job.")
-	} else {
-		// Pod already exists. Can safely skip creation.
-		logger.Debugf(ctx, "Pod %s Already Exists in %s. Skipping creation", pod.GetName(), pod.GetNamespace())
 	}
 
 	return LaunchSuccess, nil
@@ -172,10 +168,6 @@ func (t *Task) Monitor(ctx context.Context, tCtx core.TaskExecutionContext, kube
 	}
 
 	if phaseInfo.Info() != nil {
-		// Append sub-job status in Log Name for viz.
-		for _, log := range phaseInfo.Info().Logs {
-			log.Name += fmt.Sprintf(" (%s)", phaseInfo.Phase().String())
-		}
 		loglinks = phaseInfo.Info().Logs
 	}
 

--- a/go/tasks/plugins/array/k8s/task.go
+++ b/go/tasks/plugins/array/k8s/task.go
@@ -113,7 +113,7 @@ func (t Task) Launch(ctx context.Context, tCtx core.TaskExecutionContext, kubeCl
 
 	// Check for existing pods to prevent unnecessary Resource-Quota usage: https://github.com/kubernetes/kubernetes/issues/76787
 	existingPod := &corev1.Pod{}
-	err = kubeClient.GetCache().Get(context.Background(), client.ObjectKey{
+	err = kubeClient.GetCache().Get(ctx, client.ObjectKey{
 		Namespace: pod.GetNamespace(),
 		Name:      pod.GetName(),
 	}, existingPod)

--- a/go/tasks/plugins/array/k8s/task.go
+++ b/go/tasks/plugins/array/k8s/task.go
@@ -6,11 +6,13 @@ import (
 	"strconv"
 	"strings"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/tasklog"
 
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/template"
 
-	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array"
 	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array/arraystatus"
@@ -27,7 +29,6 @@ import (
 )
 
 type Task struct {
-	LogLinks         []*idlCore.TaskLog
 	State            *arrayCore.State
 	NewArrayStatus   *arraystatus.ArrayStatus
 	Config           *Config
@@ -111,32 +112,50 @@ func (t Task) Launch(ctx context.Context, tCtx core.TaskExecutionContext, kubeCl
 		return LaunchWaiting, nil
 	}
 
-	err = kubeClient.GetClient().Create(ctx, pod)
-	if err != nil && !k8serrors.IsAlreadyExists(err) {
-		if k8serrors.IsForbidden(err) {
-			if strings.Contains(err.Error(), "exceeded quota") {
-				// TODO: Quota errors are retried forever, it would be good to have support for backoff strategy.
-				logger.Infof(ctx, "Failed to launch  job, resource quota exceeded. Err: %v", err)
-				t.State = t.State.SetPhase(arrayCore.PhaseWaitingForResources, 0).SetReason("Not enough resources to launch job")
-			} else {
-				t.State = t.State.SetPhase(arrayCore.PhaseRetryableFailure, 0).SetReason("Failed to launch job.")
+	// Check for existing pods to prevent unnecessary Resource-Quota usage: https://github.com/kubernetes/kubernetes/issues/76787
+	existingPod := &corev1.Pod{}
+	err = kubeClient.GetClient().Get(context.Background(), client.ObjectKey{
+		Namespace: pod.GetNamespace(),
+		Name:      pod.GetName(),
+	}, existingPod)
+
+	if err != nil && k8serrors.IsNotFound(err) {
+		// Attempt creating non-existing pod.
+		err = kubeClient.GetClient().Create(ctx, pod)
+		if err != nil && !k8serrors.IsAlreadyExists(err) {
+			if k8serrors.IsForbidden(err) {
+				if strings.Contains(err.Error(), "exceeded quota") {
+					// TODO: Quota errors are retried forever, it would be good to have support for backoff strategy.
+					logger.Infof(ctx, "Failed to launch  job, resource quota exceeded. Err: %v", err)
+					t.State = t.State.SetPhase(arrayCore.PhaseWaitingForResources, 0).SetReason("Not enough resources to launch job")
+				} else {
+					t.State = t.State.SetPhase(arrayCore.PhaseRetryableFailure, 0).SetReason("Failed to launch job.")
+				}
+
+				t.State = t.State.SetReason(err.Error())
+				return LaunchReturnState, nil
 			}
 
-			t.State = t.State.SetReason(err.Error())
-			return LaunchReturnState, nil
+			return LaunchError, errors2.Wrapf(ErrSubmitJob, err, "Failed to submit job.")
 		}
-
+	} else if err != nil {
+		// Another error returned.
+		logger.Error(ctx, err)
 		return LaunchError, errors2.Wrapf(ErrSubmitJob, err, "Failed to submit job.")
+	} else {
+		// Pod already exists. Can safely skip creation.
+		logger.Debugf(ctx, "Pod %s Already Exists in %s. Skipping creation", pod.GetName(), pod.GetNamespace())
 	}
 
 	return LaunchSuccess, nil
 }
 
 func (t *Task) Monitor(ctx context.Context, tCtx core.TaskExecutionContext, kubeClient core.KubeClient, dataStore *storage.DataStore, outputPrefix, baseOutputDataSandbox storage.DataReference,
-	logPlugin tasklog.Plugin) (MonitorResult, error) {
+	logPlugin tasklog.Plugin) (MonitorResult, []*idlCore.TaskLog, error) {
 	indexStr := strconv.Itoa(t.ChildIdx)
 	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr)
 	t.SubTaskIDs = append(t.SubTaskIDs, &podName)
+	var loglinks []*idlCore.TaskLog
 
 	// Use original-index for log-name/links
 	originalIdx := arrayCore.CalculateOriginalIndex(t.ChildIdx, t.State.GetIndexesToCache())
@@ -149,7 +168,7 @@ func (t *Task) Monitor(ctx context.Context, tCtx core.TaskExecutionContext, kube
 		tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetID().RetryAttempt,
 		logPlugin)
 	if err != nil {
-		return MonitorError, errors2.Wrapf(ErrCheckPodStatus, err, "Failed to check pod status.")
+		return MonitorError, loglinks, errors2.Wrapf(ErrCheckPodStatus, err, "Failed to check pod status.")
 	}
 
 	if phaseInfo.Info() != nil {
@@ -157,7 +176,7 @@ func (t *Task) Monitor(ctx context.Context, tCtx core.TaskExecutionContext, kube
 		for _, log := range phaseInfo.Info().Logs {
 			log.Name += fmt.Sprintf(" (%s)", phaseInfo.Phase().String())
 		}
-		t.LogLinks = append(t.LogLinks, phaseInfo.Info().Logs...)
+		loglinks = phaseInfo.Info().Logs
 	}
 
 	if phaseInfo.Err() != nil {
@@ -168,14 +187,14 @@ func (t *Task) Monitor(ctx context.Context, tCtx core.TaskExecutionContext, kube
 	if phaseInfo.Phase().IsSuccess() {
 		actualPhase, err = array.CheckTaskOutput(ctx, dataStore, outputPrefix, baseOutputDataSandbox, t.ChildIdx, originalIdx)
 		if err != nil {
-			return MonitorError, err
+			return MonitorError, loglinks, err
 		}
 	}
 
 	t.NewArrayStatus.Detailed.SetItem(t.ChildIdx, bitarray.Item(actualPhase))
 	t.NewArrayStatus.Summary.Inc(actualPhase)
 
-	return MonitorSuccess, nil
+	return MonitorSuccess, loglinks, nil
 }
 
 func (t Task) Abort(ctx context.Context, tCtx core.TaskExecutionContext, kubeClient core.KubeClient) error {


### PR DESCRIPTION
# TL;DR
Fixes the following:

- **Log-links for partially running jobs**: If some sub-tasks are running while others are waiting for resources/tokens, the status returned is `PhaseWaitingForResources` which currently doesn't support logs. Added a new method with support for logs. Will deprecate the older one once this is checked in and all references are updated in FlytePropeller.

- **Resource Quotas Issues**:   Re-submitting all sub-jobs on each sync incorrectly increase the quota usage and causes quota issues due to quota being an admission control invoked before etc.d rejects the request as resource already exists. (https://github.com/kubernetes/kubernetes/issues/76787 ). This is reconciled in the background (usually after a few minutes) but is still an issue for batch jobs till the initial sub-jobs succeed, they will keep on getting re-tried/increase quota usage.  Added a get check to fix this.  This is also an issue at other places where we rely on resubmit/de-dupe behavior but a larger issue with Batch jobs where there can be 1000s of pods getting re-submitted. 


## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
