### PR TITLE
[K8s-array] Add default annotations/labels

### DIFF
--- a/go/tasks/plugins/array/k8s/transformer.go
+++ b/go/tasks/plugins/array/k8s/transformer.go
@@ -2,6 +2,8 @@ package k8s
 
 import (
 	"context"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
 	"regexp"
 
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
@@ -81,6 +83,9 @@ func FlyteArrayJobToK8sPodTemplate(ctx context.Context, tCtx core.TaskExecutionC
 		return v1.Pod{}, nil, err
 	}
 
+	annotations := utils.UnionMaps(config.GetK8sPluginConfig().DefaultAnnotations, tCtx.TaskExecutionMetadata().GetAnnotations())
+	labels := utils.UnionMaps(config.GetK8sPluginConfig().DefaultLabels, tCtx.TaskExecutionMetadata().GetLabels())
+
 	return v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       PodKind,
@@ -89,8 +94,8 @@ func FlyteArrayJobToK8sPodTemplate(ctx context.Context, tCtx core.TaskExecutionC
 		ObjectMeta: metav1.ObjectMeta{
 			// Note that name is missing here
 			Namespace:       GetNamespaceForExecution(tCtx, namespaceTemplate),
-			Labels:          tCtx.TaskExecutionMetadata().GetLabels(),
-			Annotations:     tCtx.TaskExecutionMetadata().GetAnnotations(),
+			Labels:          labels,
+			Annotations:     annotations,
 			OwnerReferences: []metav1.OwnerReference{tCtx.TaskExecutionMetadata().GetOwnerReference()},
 		},
 		Spec: *podSpec,

--- a/go/tasks/plugins/array/k8s/transformer.go
+++ b/go/tasks/plugins/array/k8s/transformer.go
@@ -2,9 +2,10 @@ package k8s
 
 import (
 	"context"
+	"regexp"
+
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
-	"regexp"
 
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
 


### PR DESCRIPTION
# TL;DR
Since K8s-array pods don't go through common resource-creation logic in Propeller, labels/annotations are missed. Adding them similar to how we do for spark plugin.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
