### PR TITLE
Greater consistency in map pod task pod spec construction

### DIFF
--- a/go/tasks/plugins/array/k8s/transformer.go
+++ b/go/tasks/plugins/array/k8s/transformer.go
@@ -94,6 +94,40 @@ func buildPodMapTask(task *idlCore.TaskTemplate, metadata core.TaskExecutionMeta
 	return pod, nil
 }
 
+// Here we customize the k8sPod primary container by templatizing args.
+// The call to ToK8sPodSpec for the task container target
+// case already handles this but we must explicitly do so for K8sPod task targets.
+func modifyMapPodTaskPrimaryContainer(ctx context.Context, tCtx core.TaskExecutionContext, arrTCtx *arrayTaskContext, container *v1.Container) error {
+	var err error
+	container.Args, err = template.Render(ctx, container.Args,
+		template.Parameters{
+			TaskExecMetadata: tCtx.TaskExecutionMetadata(),
+			Inputs:           arrTCtx.arrayInputReader,
+			OutputPath:       tCtx.OutputWriter(),
+			Task:             tCtx.TaskReader(),
+		})
+	if err != nil {
+		return err
+	}
+	container.Command, err = template.Render(ctx, container.Command,
+		template.Parameters{
+			TaskExecMetadata: tCtx.TaskExecutionMetadata(),
+			Inputs:           arrTCtx.arrayInputReader,
+			OutputPath:       tCtx.OutputWriter(),
+			Task:             tCtx.TaskReader(),
+		})
+	if err != nil {
+		return err
+	}
+	resources := flytek8s.ApplyResourceOverrides(ctx, container.Resources)
+	if resources != nil {
+		container.Resources = *resources
+	}
+
+	container.Env = flytek8s.DecorateEnvVars(ctx, container.Env, tCtx.TaskExecutionMetadata().GetTaskExecutionID())
+	return nil
+}
+
 // Note that Name is not set on the result object.
 // It's up to the caller to set the Name before creating the object in K8s.
 func FlyteArrayJobToK8sPodTemplate(ctx context.Context, tCtx core.TaskExecutionContext, namespaceTemplate string) (
@@ -155,29 +189,11 @@ func FlyteArrayJobToK8sPodTemplate(ctx context.Context, tCtx core.TaskExecutionC
 		pod.Annotations = utils.UnionMaps(pod.Annotations, k8sPod.Annotations)
 		pod.Spec = k8sPod.Spec
 
-		// Here we templatize the k8sPod primary container args. The call to ToK8sPodSpec for the task container target
-		// case already handles this but we must explicitly do so for K8sPod task targets.
 		containerIndex, err := getTaskContainerIndex(&pod)
 		if err != nil {
 			return v1.Pod{}, nil, err
 		}
-		pod.Spec.Containers[containerIndex].Args, err = template.Render(ctx, pod.Spec.Containers[containerIndex].Args,
-			template.Parameters{
-				TaskExecMetadata: tCtx.TaskExecutionMetadata(),
-				Inputs:           arrTCtx.arrayInputReader,
-				OutputPath:       tCtx.OutputWriter(),
-				Task:             tCtx.TaskReader(),
-			})
-		if err != nil {
-			return v1.Pod{}, nil, err
-		}
-		pod.Spec.Containers[containerIndex].Command, err = template.Render(ctx, pod.Spec.Containers[containerIndex].Command,
-			template.Parameters{
-				TaskExecMetadata: tCtx.TaskExecutionMetadata(),
-				Inputs:           arrTCtx.arrayInputReader,
-				OutputPath:       tCtx.OutputWriter(),
-				Task:             tCtx.TaskReader(),
-			})
+		err = modifyMapPodTaskPrimaryContainer(ctx, tCtx, arrTCtx, &pod.Spec.Containers[containerIndex])
 		if err != nil {
 			return v1.Pod{}, nil, err
 		}


### PR DESCRIPTION
Signed-off-by: Katrina Rogan <katroganGH@gmail.com>

# TL;DR
Apply conventional resource and env var overrides in map pod tasks. This is [already done](https://github.com/flyteorg/flyteplugins/blob/master/go/tasks/plugins/k8s/sidecar/sidecar.go#L64,L65) for regular pod tasks.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
User reported bug

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1223

## Follow-up issue
_NA_
