### PR TITLE
Support setting ephemeral storage

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/container_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper.go
@@ -73,7 +73,6 @@ func ApplyResourceOverrides(ctx context.Context, resources v1.ResourceRequiremen
 	// TODO: Make configurable. 1/15/2019 Flyte Cluster doesn't support setting storage requests/limits.
 	// https://github.com/kubernetes/enhancements/issues/362
 	delete(resources.Requests, v1.ResourceStorage)
-
 	delete(resources.Limits, v1.ResourceStorage)
 
 	// Override GPU

--- a/go/tasks/pluginmachinery/flytek8s/container_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper.go
@@ -60,13 +60,21 @@ func ApplyResourceOverrides(ctx context.Context, resources v1.ResourceRequiremen
 		resources.Limits[v1.ResourceMemory] = resources.Requests[v1.ResourceMemory]
 	}
 
+	// Ephemeral storage resources aren't required but if one of requests or limits is set and the other isn't, we'll
+	// just use the same values.
+	if _, requested := resources.Requests[v1.ResourceEphemeralStorage]; !requested {
+		if _, limitSet := resources.Limits[v1.ResourceEphemeralStorage]; limitSet {
+			resources.Requests[v1.ResourceEphemeralStorage] = resources.Limits[v1.ResourceEphemeralStorage]
+		}
+	} else if _, limitSet := resources.Limits[v1.ResourceEphemeralStorage]; !limitSet {
+		resources.Limits[v1.ResourceEphemeralStorage] = resources.Requests[v1.ResourceEphemeralStorage]
+	}
+
 	// TODO: Make configurable. 1/15/2019 Flyte Cluster doesn't support setting storage requests/limits.
 	// https://github.com/kubernetes/enhancements/issues/362
 	delete(resources.Requests, v1.ResourceStorage)
-	delete(resources.Requests, v1.ResourceEphemeralStorage)
 
 	delete(resources.Limits, v1.ResourceStorage)
-	delete(resources.Limits, v1.ResourceEphemeralStorage)
 
 	// Override GPU
 	if res, found := resources.Requests[resourceGPU]; found {

--- a/go/tasks/pluginmachinery/flytek8s/container_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper_test.go
@@ -81,6 +81,37 @@ func TestApplyResourceOverrides_OverrideMemory(t *testing.T) {
 	assert.EqualValues(t, cpuLimit, overrides.Requests[v1.ResourceCPU])
 }
 
+func TestApplyResourceOverrides_OverrideEphemeralStorage(t *testing.T) {
+	ephemeralStorageRequest := resource.MustParse("1")
+	overrides := ApplyResourceOverrides(context.Background(), v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceEphemeralStorage: ephemeralStorageRequest,
+		},
+	})
+	assert.EqualValues(t, ephemeralStorageRequest, overrides.Requests[v1.ResourceEphemeralStorage])
+	assert.EqualValues(t, ephemeralStorageRequest, overrides.Limits[v1.ResourceEphemeralStorage])
+
+	ephemeralStorageLimit := resource.MustParse("2")
+	overrides = ApplyResourceOverrides(context.Background(), v1.ResourceRequirements{
+		Requests: v1.ResourceList{
+			v1.ResourceEphemeralStorage: ephemeralStorageRequest,
+		},
+		Limits: v1.ResourceList{
+			v1.ResourceEphemeralStorage: ephemeralStorageLimit,
+		},
+	})
+	assert.EqualValues(t, ephemeralStorageRequest, overrides.Requests[v1.ResourceEphemeralStorage])
+	assert.EqualValues(t, ephemeralStorageLimit, overrides.Limits[v1.ResourceEphemeralStorage])
+
+	// request equals limit if not set
+	overrides = ApplyResourceOverrides(context.Background(), v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			v1.ResourceEphemeralStorage: ephemeralStorageLimit,
+		},
+	})
+	assert.EqualValues(t, ephemeralStorageLimit, overrides.Requests[v1.ResourceEphemeralStorage])
+}
+
 func TestApplyResourceOverrides_RemoveStorage(t *testing.T) {
 	requestedResourceQuantity := resource.MustParse("1")
 	overrides := ApplyResourceOverrides(context.Background(), v1.ResourceRequirements{
@@ -97,13 +128,15 @@ func TestApplyResourceOverrides_RemoveStorage(t *testing.T) {
 		},
 	})
 	assert.EqualValues(t, v1.ResourceList{
-		v1.ResourceMemory: requestedResourceQuantity,
-		v1.ResourceCPU:    requestedResourceQuantity,
+		v1.ResourceMemory:           requestedResourceQuantity,
+		v1.ResourceCPU:              requestedResourceQuantity,
+		v1.ResourceEphemeralStorage: requestedResourceQuantity,
 	}, overrides.Requests)
 
 	assert.EqualValues(t, v1.ResourceList{
-		v1.ResourceMemory: requestedResourceQuantity,
-		v1.ResourceCPU:    requestedResourceQuantity,
+		v1.ResourceMemory:           requestedResourceQuantity,
+		v1.ResourceCPU:              requestedResourceQuantity,
+		v1.ResourceEphemeralStorage: requestedResourceQuantity,
 	}, overrides.Limits)
 }
 


### PR DESCRIPTION
# TL;DR
Now that k8s supports setting ephemeral storage we should expose that as a configurable setting to end users. At the very least this change allows doing so in pod tasks.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/flyteorg/flyte/issues/494

## Follow-up issue
_NA_
