### PR TITLE
Fix resource requirements for sidecar/pod tasks

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/container_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper.go
@@ -22,6 +22,23 @@ const resourceGPU = "gpu"
 // Copied from: k8s.io/autoscaler/cluster-autoscaler/utils/gpu/gpu.go
 const ResourceNvidiaGPU = "nvidia.com/gpu"
 
+func MergeResources(in v1.ResourceRequirements, out *v1.ResourceRequirements) {
+	if out.Limits == nil {
+		out.Limits = in.Limits
+	} else if in.Limits != nil {
+		for key, val := range in.Limits {
+			out.Limits[key] = val
+		}
+	}
+	if out.Requests == nil {
+		out.Requests = in.Requests
+	} else if in.Requests != nil {
+		for key, val := range in.Requests {
+			out.Requests[key] = val
+		}
+	}
+}
+
 func ApplyResourceOverrides(ctx context.Context, resources v1.ResourceRequirements) *v1.ResourceRequirements {
 	// set memory and cpu to default if not provided by user.
 	if len(resources.Requests) == 0 {

--- a/go/tasks/plugins/k8s/sidecar/sidecar_test.go
+++ b/go/tasks/plugins/k8s/sidecar/sidecar_test.go
@@ -35,8 +35,8 @@ const ResourceNvidiaGPU = "nvidia.com/gpu"
 
 var resourceRequirements = &v1.ResourceRequirements{
 	Limits: v1.ResourceList{
-		v1.ResourceCPU:     resource.MustParse("1024m"),
-		v1.ResourceStorage: resource.MustParse("100M"),
+		v1.ResourceCPU:              resource.MustParse("2048m"),
+		v1.ResourceEphemeralStorage: resource.MustParse("100M"),
 	},
 }
 
@@ -243,6 +243,17 @@ func TestBuildSidecarResource_TaskType2(t *testing.T) {
 	assert.Equal(t, "volume mount", res.(*v1.Pod).Spec.Containers[0].VolumeMounts[0].Name)
 	checkUserTolerations(t, res)
 
+	// Assert resource requirements are correctly set
+	expectedCPURequest := resource.MustParse("1")
+	assert.Equal(t, expectedCPURequest.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Requests.Cpu().Value())
+	expectedMemRequest := resource.MustParse("100Mi")
+	assert.Equal(t, expectedMemRequest.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Requests.Memory().Value())
+	expectedCPULimit := resource.MustParse("2048m")
+	assert.Equal(t, expectedCPULimit.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Limits.Cpu().Value())
+	expectedMemLimit := resource.MustParse("200Mi")
+	assert.Equal(t, expectedMemLimit.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Limits.Memory().Value())
+	expectedEphemeralStorageLimit := resource.MustParse("100M")
+	assert.Equal(t, expectedEphemeralStorageLimit.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Limits.StorageEphemeral().Value())
 }
 
 func TestBuildSidecarResource_TaskType2_Invalid_Spec(t *testing.T) {
@@ -330,6 +341,18 @@ func TestBuildSidecarResource_TaskType1(t *testing.T) {
 	assert.Equal(t, "volume mount", res.(*v1.Pod).Spec.Containers[0].VolumeMounts[0].Name)
 
 	checkUserTolerations(t, res)
+
+	// Assert resource requirements are correctly set
+	expectedCPURequest := resource.MustParse("1")
+	assert.Equal(t, expectedCPURequest.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Requests.Cpu().Value())
+	expectedMemRequest := resource.MustParse("100Mi")
+	assert.Equal(t, expectedMemRequest.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Requests.Memory().Value())
+	expectedCPULimit := resource.MustParse("2048m")
+	assert.Equal(t, expectedCPULimit.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Limits.Cpu().Value())
+	expectedMemLimit := resource.MustParse("200Mi")
+	assert.Equal(t, expectedMemLimit.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Limits.Memory().Value())
+	expectedEphemeralStorageLimit := resource.MustParse("100M")
+	assert.Equal(t, expectedEphemeralStorageLimit.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Limits.StorageEphemeral().Value())
 }
 
 func TestBuildSideResource_TaskType1_InvalidSpec(t *testing.T) {
@@ -453,6 +476,18 @@ func TestBuildSidecarResource(t *testing.T) {
 			t.Fatalf("unexpected toleration [%+v]", tol)
 		}
 	}
+
+	// Assert resource requirements are correctly set
+	expectedCPURequest := resource.MustParse("1024m")
+	assert.Equal(t, expectedCPURequest.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Requests.Cpu().Value())
+	expectedMemRequest := resource.MustParse("1024Mi")
+	assert.Equal(t, expectedMemRequest.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Requests.Memory().Value())
+	expectedCPULimit := resource.MustParse("2048m")
+	assert.Equal(t, expectedCPULimit.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Limits.Cpu().Value())
+	expectedMemLimit := resource.MustParse("1024Mi")
+	assert.Equal(t, expectedMemLimit.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Limits.Memory().Value())
+	expectedEphemeralStorageLimit := resource.MustParse("100M")
+	assert.Equal(t, expectedEphemeralStorageLimit.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Limits.StorageEphemeral().Value())
 }
 
 func TestBuildSidecarReosurceMissingAnnotationsAndLabels(t *testing.T) {


### PR DESCRIPTION
# TL;DR
Fixes task node resource overrides via `.with_overrides` in flytekit not applying to resource requirements in sidecar/pod tasks. Also fixes k8s plugin default resource requests not applying to sidecar/pod tasks.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Merges task node resource requirements with resource requirements of primary container in sidecar/pod task, after applying defaults where necessary.

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1323
