### PR TITLE
Apply overrides before applying defaults to sidecar resource requirements

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/container_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper.go
@@ -60,7 +60,7 @@ func ApplyResourceOverrides(ctx context.Context, resources v1.ResourceRequiremen
 
 	if _, found := resources.Requests[v1.ResourceMemory]; !found {
 		// use memory limit if set else default to config
-		if _, limitSet := resources.Limits[v1.ResourceCPU]; limitSet {
+		if _, limitSet := resources.Limits[v1.ResourceMemory]; limitSet {
 			resources.Requests[v1.ResourceMemory] = resources.Limits[v1.ResourceMemory]
 		} else {
 			resources.Requests[v1.ResourceMemory] = resource.MustParse(config.GetK8sPluginConfig().DefaultMemoryRequest)

--- a/go/tasks/pluginmachinery/flytek8s/container_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper_test.go
@@ -29,13 +29,6 @@ func TestApplyResourceOverrides_OverrideCpu(t *testing.T) {
 		},
 	})
 	assert.EqualValues(t, cpuRequest, overrides.Requests[v1.ResourceCPU])
-
-	// request equals limit if not set
-	overrides = ApplyResourceOverrides(context.Background(), v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU: cpuLimit,
-		},
-	})
 	assert.EqualValues(t, cpuLimit, overrides.Limits[v1.ResourceCPU])
 
 	// request equals limit if not set
@@ -45,6 +38,7 @@ func TestApplyResourceOverrides_OverrideCpu(t *testing.T) {
 		},
 	})
 	assert.EqualValues(t, cpuLimit, overrides.Requests[v1.ResourceCPU])
+	assert.EqualValues(t, cpuLimit, overrides.Limits[v1.ResourceCPU])
 }
 
 func TestApplyResourceOverrides_OverrideMemory(t *testing.T) {
@@ -70,15 +64,13 @@ func TestApplyResourceOverrides_OverrideMemory(t *testing.T) {
 	assert.EqualValues(t, memoryLimit, overrides.Limits[v1.ResourceMemory])
 
 	// request equals limit if not set
-	cpuLimit := resource.MustParse("2")
 	overrides = ApplyResourceOverrides(context.Background(), v1.ResourceRequirements{
 		Limits: v1.ResourceList{
 			v1.ResourceMemory: memoryLimit,
-			v1.ResourceCPU:    cpuLimit,
 		},
 	})
 	assert.EqualValues(t, memoryLimit, overrides.Requests[v1.ResourceMemory])
-	assert.EqualValues(t, cpuLimit, overrides.Requests[v1.ResourceCPU])
+	assert.EqualValues(t, memoryLimit, overrides.Limits[v1.ResourceMemory])
 }
 
 func TestApplyResourceOverrides_OverrideEphemeralStorage(t *testing.T) {

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -197,8 +197,10 @@ func TestToK8sPod(t *testing.T) {
 		ResourceTolerations: map[v1.ResourceName][]v1.Toleration{
 			v1.ResourceStorage: {tolStorage},
 			ResourceNvidiaGPU:  {tolGPU},
-		}}),
-	)
+		},
+		DefaultCPURequest:    "1024m",
+		DefaultMemoryRequest: "1024Mi",
+	}))
 
 	op := &pluginsIOMock.OutputFilePaths{}
 	op.On("GetOutputPrefixPath").Return(storage.DataReference(""))
@@ -262,7 +264,9 @@ func TestToK8sPod(t *testing.T) {
 			DefaultNodeSelector: map[string]string{
 				"nodeId": "123",
 			},
-			SchedulerName: "myScheduler",
+			SchedulerName:        "myScheduler",
+			DefaultCPURequest:    "1024m",
+			DefaultMemoryRequest: "1024Mi",
 		}))
 
 		p, err := ToK8sPodSpec(ctx, x)

--- a/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
+++ b/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
@@ -6,6 +6,8 @@ plugins:
   # All k8s plugins default configuration
   k8s:
     scheduler-name: flyte-scheduler
+    default-cpus: 1024m
+    default-memory: 1024Mi
     default-annotations:
       - annotationKey1: annotationValue1
       - annotationKey2: annotationValue2

--- a/go/tasks/plugins/k8s/sidecar/sidecar.go
+++ b/go/tasks/plugins/k8s/sidecar/sidecar.go
@@ -39,11 +39,11 @@ func validateAndFinalizePod(
 	for index, container := range pod.Spec.Containers {
 		if container.Name == primaryContainerName {
 			hasPrimaryContainer = true
-			container.Resources = *flytek8s.ApplyResourceOverrides(ctx, container.Resources)
 			if taskCtx.TaskExecutionMetadata().GetOverrides() != nil && taskCtx.TaskExecutionMetadata().GetOverrides().GetResources() != nil {
 				resOverrides := taskCtx.TaskExecutionMetadata().GetOverrides().GetResources()
 				flytek8s.MergeResources(*resOverrides, &container.Resources)
 			}
+			container.Resources = *flytek8s.ApplyResourceOverrides(ctx, container.Resources)
 		}
 		modifiedCommand, err := template.Render(ctx, container.Command, template.Parameters{
 			TaskExecMetadata: taskCtx.TaskExecutionMetadata(),

--- a/go/tasks/plugins/k8s/sidecar/sidecar_test.go
+++ b/go/tasks/plugins/k8s/sidecar/sidecar_test.go
@@ -478,7 +478,7 @@ func TestBuildSidecarResource(t *testing.T) {
 	}
 
 	// Assert resource requirements are correctly set
-	expectedCPURequest := resource.MustParse("1024m")
+	expectedCPURequest := resource.MustParse("2048m")
 	assert.Equal(t, expectedCPURequest.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Requests.Cpu().Value())
 	expectedMemRequest := resource.MustParse("1024Mi")
 	assert.Equal(t, expectedMemRequest.Value(), res.(*v1.Pod).Spec.Containers[0].Resources.Requests.Memory().Value())


### PR DESCRIPTION
# TL;DR
Apply overrides before applying defaults to sidecar resource requirements. Related to: https://github.com/flyteorg/flyteplugins/pull/194.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Refactored code to apply resource requirements overrides from node spec first before applying default resource requirements. Found a bug in `ApplyResourceOverrides` as a result, and fixed the unit tests to properly catch the issue.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
