### PR TITLE
Add grace period to allow resolution of transient `CreateContainerError`

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/config/config.go
+++ b/go/tasks/pluginmachinery/flytek8s/config/config.go
@@ -40,6 +40,9 @@ var (
 		},
 		DefaultCPURequest:    defaultCPURequest,
 		DefaultMemoryRequest: defaultMemoryRequest,
+		CreateContainerErrorGracePeriod: config2.Duration{
+			Duration: time.Minute * 3,
+		},
 	}
 
 	// K8sPluginConfigSection provides a singular top level config section for all plugins.
@@ -110,6 +113,11 @@ type K8sPluginConfig struct {
 	// are kept around (potentially consuming cluster resources). This, however, will cause k8s log links to expire as
 	// soon as the resource is finalized.
 	DeleteResourceOnFinalize bool `json:"delete-resource-on-finalize" pflag:",Instructs the system to delete the resource on finalize. This ensures that no resources are kept around (potentially consuming cluster resources). This, however, will cause k8s log links to expire as soon as the resource is finalized."`
+
+	// Time to wait for transient CreateContainerError errors to be resolved. If the
+	// error persists past this grace period, it will be inferred to be a permanent
+	// one, and the corresponding task marked as failed
+	CreateContainerErrorGracePeriod config2.Duration `json:"create-container-error-grace-period" pflag:"-,Time to wait for transient CreateContainerError errors to be resolved."`
 }
 
 type FlyteCoPilotConfig struct {

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -232,6 +232,14 @@ func DemystifyPending(status v1.PodStatus) (pluginsCore.PhaseInfo, error) {
 								// transient issues with the container runtime. If the
 								// error persists beyond this time, the corresponding
 								// task is marked as failed.
+								// NOTE: The current implementation checks for a timeout
+								// by comparing the condition's LastTransitionTime
+								// based on the corresponding kubelet's clock with the
+								// current time based on FlytePropeller's clock. This
+								// is not ideal given that these 2 clocks are NOT
+								// synced, and therefore, only provides an
+								// approximation of the elapsed time since the last
+								// transition.
 								t := c.LastTransitionTime.Time
 								if time.Since(t) >= config.GetK8sPluginConfig().CreateContainerErrorGracePeriod.Duration {
 									return pluginsCore.PhaseInfoFailure(finalReason, finalMessage, &pluginsCore.TaskInfo{

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -233,7 +233,7 @@ func DemystifyPending(status v1.PodStatus) (pluginsCore.PhaseInfo, error) {
 								// error persists beyond this time, the corresponding
 								// task is marked as failed.
 								t := c.LastTransitionTime.Time
-								if v12.Now().After(t.Add(config.GetK8sPluginConfig().CreateContainerErrorGracePeriod.Duration)) {
+								if time.Since(t) >= config.GetK8sPluginConfig().CreateContainerErrorGracePeriod.Duration {
 									return pluginsCore.PhaseInfoFailure(finalReason, finalMessage, &pluginsCore.TaskInfo{
 										OccurredAt: &t,
 									}), nil

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -220,8 +220,32 @@ func DemystifyPending(status v1.PodStatus) (pluginsCore.PhaseInfo, error) {
 								// PodInitializing -> Init containers are running
 								return pluginsCore.PhaseInfoInitializing(c.LastTransitionTime.Time, pluginsCore.DefaultPhaseVersion, fmt.Sprintf("[%s]: %s", finalReason, finalMessage), &pluginsCore.TaskInfo{OccurredAt: &c.LastTransitionTime.Time}), nil
 
-							case "CreateContainerConfigError", "CreateContainerError":
-								// This happens if for instance the command to the container is incorrect, ie doesn't run
+							case "CreateContainerError":
+								// This may consist of:
+								// 1. Transient errors: e.g. failed to reserve
+								// container name, container name [...] already in use
+								// by container
+								// 2. Permanent errors: e.g. no command specified
+								// To handle both types of errors gracefully without
+								// arbitrary pattern matching in the message, we simply
+								// allow a grace period for kubelet to resolve
+								// transient issues with the container runtime. If the
+								// error persists beyond this time, the corresponding
+								// task is marked as failed.
+								t := c.LastTransitionTime.Time
+								if v12.Now().After(t.Add(config.GetK8sPluginConfig().CreateContainerErrorGracePeriod.Duration)) {
+									return pluginsCore.PhaseInfoFailure(finalReason, finalMessage, &pluginsCore.TaskInfo{
+										OccurredAt: &t,
+									}), nil
+								}
+								return pluginsCore.PhaseInfoInitializing(
+									t,
+									pluginsCore.DefaultPhaseVersion,
+									fmt.Sprintf("[%s]: %s", finalReason, finalMessage),
+									&pluginsCore.TaskInfo{OccurredAt: &t},
+								), nil
+
+							case "CreateContainerConfigError":
 								t := c.LastTransitionTime.Time
 								return pluginsCore.PhaseInfoFailure(finalReason, finalMessage, &pluginsCore.TaskInfo{
 									OccurredAt: &t,


### PR DESCRIPTION
Signed-off-by: Jeev B <jeev.balakrishnan@freenome.com>

# TL;DR
Adds grace period to allow resolution of transient `CreateContainerError`

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Adds the `CreateContainerErrorGracePeriod` config option to the k8s plugin that specifies the amount of time to allow for `CreateContainerError` to be resolved by kubelet + container runtime, before marking the corresponding task as permanently failed. This grace period is used within `DemystifyPending`.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/1234

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
