### PR TITLE
Add Snowflake backend plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,3 +52,5 @@ require (
 )
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
+
+replace github.com/flyteorg/flyteidl => github.com/pingsutw/flyteidl v0.18.1-0.20210827093343-f99365ab61aa

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.0.0
 	github.com/aws/aws-sdk-go-v2/service/athena v1.0.0
 	github.com/coocood/freecache v1.1.1
-	github.com/flyteorg/flyteidl v0.20.0
+	github.com/flyteorg/flyteidl v0.20.1
 	github.com/flyteorg/flytestdlib v0.3.33
 	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/go-test/deep v1.0.7
@@ -52,5 +52,3 @@ require (
 )
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
-
-replace github.com/flyteorg/flyteidl => github.com/pingsutw/flyteidl v0.18.1-0.20210827093343-f99365ab61aa

--- a/go.sum
+++ b/go.sum
@@ -226,6 +226,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
+github.com/flyteorg/flyteidl v0.20.1 h1:S+jJBmtRtzUcLNAgXJNsVza/6SRS/cmtKu/zAUvC6+U=
+github.com/flyteorg/flyteidl v0.20.1/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/flyteorg/flytestdlib v0.3.33 h1:+oCx3zXUIldL7CWmNMD7PMFPXvGqaPgYkSKn9wB6qvY=
 github.com/flyteorg/flytestdlib v0.3.33/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=
@@ -598,8 +600,6 @@ github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
-github.com/pingsutw/flyteidl v0.18.1-0.20210827093343-f99365ab61aa h1:aoPghkmTbSurr9fKWtKG1HqrqtyEvEAfl3oUlmpowzs=
-github.com/pingsutw/flyteidl v0.18.1-0.20210827093343-f99365ab61aa/go.mod h1:zt93wYZh4WcqPwrF8+WVDV14+fLVoGB9HA+cx9/w/5E=
 github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,6 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
-github.com/flyteorg/flyteidl v0.20.0 h1:g5xGayFfPSzFJxJedgL390WFSEbGYjFiPey+NXAB030=
-github.com/flyteorg/flyteidl v0.20.0/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/flyteorg/flytestdlib v0.3.33 h1:+oCx3zXUIldL7CWmNMD7PMFPXvGqaPgYkSKn9wB6qvY=
 github.com/flyteorg/flytestdlib v0.3.33/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=
@@ -600,6 +598,8 @@ github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
+github.com/pingsutw/flyteidl v0.18.1-0.20210827093343-f99365ab61aa h1:aoPghkmTbSurr9fKWtKG1HqrqtyEvEAfl3oUlmpowzs=
+github.com/pingsutw/flyteidl v0.18.1-0.20210827093343-f99365ab61aa/go.mod h1:zt93wYZh4WcqPwrF8+WVDV14+fLVoGB9HA+cx9/w/5E=
 github.com/pkg/browser v0.0.0-20210115035449-ce105d075bb4/go.mod h1:N6UoU20jOqggOuDwUaBQpluzLNDqif3kq9z2wpdYEfQ=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go/tasks/plugins/webapi/snowflake/config.go
+++ b/go/tasks/plugins/webapi/snowflake/config.go
@@ -1,0 +1,65 @@
+package snowflake
+
+import (
+	"time"
+
+	pluginsConfig "github.com/flyteorg/flyteplugins/go/tasks/config"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi"
+	"github.com/flyteorg/flytestdlib/config"
+)
+
+var (
+	defaultConfig = Config{
+		WebAPI: webapi.PluginConfig{
+			ResourceQuotas: map[core.ResourceNamespace]int{
+				"default": 1000,
+			},
+			ReadRateLimiter: webapi.RateLimiterConfig{
+				Burst: 100,
+				QPS:   10,
+			},
+			WriteRateLimiter: webapi.RateLimiterConfig{
+				Burst: 100,
+				QPS:   10,
+			},
+			Caching: webapi.CachingConfig{
+				Size:              500000,
+				ResyncInterval:    config.Duration{Duration: 30 * time.Second},
+				Workers:           10,
+				MaxSystemFailures: 5,
+			},
+			ResourceMeta: nil,
+		},
+		ResourceConstraints: core.ResourceConstraintsSpec{
+			ProjectScopeResourceConstraint: &core.ResourceConstraint{
+				Value: 100,
+			},
+			NamespaceScopeResourceConstraint: &core.ResourceConstraint{
+				Value: 50,
+			},
+		},
+		DefaultWarehouse: "COMPUTE_WH",
+	}
+
+	configSection = pluginsConfig.MustRegisterSubSection("snowflake", &defaultConfig)
+)
+
+// Config is config for 'snowflake' plugin
+type Config struct {
+	// WebAPI defines config for the base WebAPI plugin
+	WebAPI webapi.PluginConfig `json:"webApi" pflag:",Defines config for the base WebAPI plugin."`
+
+	// ResourceConstraints defines resource constraints on how many executions to be created per project/overall at any given time
+	ResourceConstraints core.ResourceConstraintsSpec `json:"resourceConstraints" pflag:"-,Defines resource constraints on how many executions to be created per project/overall at any given time."`
+
+	DefaultWarehouse string `json:"defaultWarehouse" pflag:",Defines the default warehouse to use when running on Snowflake unless overwritten by the task."`
+}
+
+func GetConfig() *Config {
+	return configSection.GetConfig().(*Config)
+}
+
+func SetConfig(cfg *Config) error {
+	return configSection.SetConfig(cfg)
+}

--- a/go/tasks/plugins/webapi/snowflake/config.go
+++ b/go/tasks/plugins/webapi/snowflake/config.go
@@ -54,6 +54,9 @@ type Config struct {
 	ResourceConstraints core.ResourceConstraintsSpec `json:"resourceConstraints" pflag:"-,Defines resource constraints on how many executions to be created per project/overall at any given time."`
 
 	DefaultWarehouse string `json:"defaultWarehouse" pflag:",Defines the default warehouse to use when running on Snowflake unless overwritten by the task."`
+
+	// snowflakeEndpoint overrides Snowflake client endpoint, only for testing
+	snowflakeEndpoint string
 }
 
 func GetConfig() *Config {

--- a/go/tasks/plugins/webapi/snowflake/config.go
+++ b/go/tasks/plugins/webapi/snowflake/config.go
@@ -47,7 +47,7 @@ var (
 
 // Config is config for 'snowflake' plugin
 type Config struct {
-	// WebAPI defines config for the base WebAPI plugin
+	// WeCreateTaskInfobAPI defines config for the base WebAPI plugin
 	WebAPI webapi.PluginConfig `json:"webApi" pflag:",Defines config for the base WebAPI plugin."`
 
 	// ResourceConstraints defines resource constraints on how many executions to be created per project/overall at any given time

--- a/go/tasks/plugins/webapi/snowflake/config.go
+++ b/go/tasks/plugins/webapi/snowflake/config.go
@@ -40,6 +40,7 @@ var (
 			},
 		},
 		DefaultWarehouse: "COMPUTE_WH",
+		TokenKey:         "FLYTE_SNOWFLAKE_CLIENT_TOKEN",
 	}
 
 	configSection = pluginsConfig.MustRegisterSubSection("snowflake", &defaultConfig)
@@ -54,6 +55,8 @@ type Config struct {
 	ResourceConstraints core.ResourceConstraintsSpec `json:"resourceConstraints" pflag:"-,Defines resource constraints on how many executions to be created per project/overall at any given time."`
 
 	DefaultWarehouse string `json:"defaultWarehouse" pflag:",Defines the default warehouse to use when running on Snowflake unless overwritten by the task."`
+
+	TokenKey string `json:"snowflakeTokenKey" pflag:",Name of the key where to find Snowflake token in the secret manager."`
 
 	// snowflakeEndpoint overrides Snowflake client endpoint, only for testing
 	snowflakeEndpoint string

--- a/go/tasks/plugins/webapi/snowflake/config_test.go
+++ b/go/tasks/plugins/webapi/snowflake/config_test.go
@@ -2,32 +2,17 @@ package snowflake
 
 import (
 	"testing"
+	"time"
 
-	pluginUtils "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestUnmarshalSnowflakeQueryConfig(t *testing.T) {
-	custom := structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"Account":   structpb.NewStringValue("test-account"),
-			"Warehouse": structpb.NewStringValue("test-warehouse"),
-			"Schema":    structpb.NewStringValue("test-schema"),
-			"Database":  structpb.NewStringValue("test-database"),
-			"Statement": structpb.NewStringValue("SELECT 1"),
-		},
-	}
-
-	prestoQuery := QueryJobConfig{}
-	err := pluginUtils.UnmarshalStructToObj(&custom, &prestoQuery)
+func TestGetAndSetConfig(t *testing.T) {
+	cfg := defaultConfig
+	cfg.DefaultWarehouse = "test-warehouse"
+	cfg.WebAPI.Caching.Workers = 1
+	cfg.WebAPI.Caching.ResyncInterval.Duration = 5 * time.Second
+	err := SetConfig(&cfg)
 	assert.NoError(t, err)
-
-	assert.Equal(t, prestoQuery, QueryJobConfig{
-		Account:   "test-account",
-		Warehouse: "test-warehouse",
-		Schema:    "test-schema",
-		Database:  "test-database",
-		Statement: "SELECT 1",
-	})
+	assert.Equal(t, &cfg, GetConfig())
 }

--- a/go/tasks/plugins/webapi/snowflake/config_test.go
+++ b/go/tasks/plugins/webapi/snowflake/config_test.go
@@ -1,0 +1,32 @@
+package snowflake
+
+import (
+	pluginUtils "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
+	"testing"
+)
+
+func TestUnmarshalSnowflakeQueryConfig(t *testing.T) {
+	custom := structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"Account":   structpb.NewStringValue("test-account"),
+			"Warehouse": structpb.NewStringValue("test-warehouse"),
+			"Schema":    structpb.NewStringValue("test-schema"),
+			"Database":  structpb.NewStringValue("test-database"),
+			"Statement": structpb.NewStringValue("SELECT 1"),
+		},
+	}
+
+	prestoQuery := QueryJobConfig{}
+	err := pluginUtils.UnmarshalStructToObj(&custom, &prestoQuery)
+	assert.NoError(t, err)
+
+	assert.Equal(t, prestoQuery, QueryJobConfig{
+		Account:   "test-account",
+		Warehouse: "test-warehouse",
+		Schema:    "test-schema",
+		Database:  "test-database",
+		Statement: "SELECT 1",
+	})
+}

--- a/go/tasks/plugins/webapi/snowflake/config_test.go
+++ b/go/tasks/plugins/webapi/snowflake/config_test.go
@@ -1,10 +1,11 @@
 package snowflake
 
 import (
+	"testing"
+
 	pluginUtils "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/types/known/structpb"
-	"testing"
 )
 
 func TestUnmarshalSnowflakeQueryConfig(t *testing.T) {

--- a/go/tasks/plugins/webapi/snowflake/integration_test.go
+++ b/go/tasks/plugins/webapi/snowflake/integration_test.go
@@ -1,0 +1,109 @@
+package snowflake
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/flyteorg/flyteidl/clients/go/coreutils"
+	flyteIdlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery"
+	pluginCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	pluginCoreMocks "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
+	pluginUtils "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
+	"github.com/flyteorg/flyteplugins/tests"
+	"github.com/flyteorg/flytestdlib/contextutils"
+	"github.com/flyteorg/flytestdlib/promutils"
+	"github.com/flyteorg/flytestdlib/promutils/labeled"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestEndToEnd(t *testing.T) {
+	server := newFakeSnowflakeServer()
+	defer server.Close()
+
+	iter := func(ctx context.Context, tCtx pluginCore.TaskExecutionContext) error {
+		return nil
+	}
+
+	cfg := defaultConfig
+	cfg.snowflakeEndpoint = server.URL
+	cfg.DefaultWarehouse = "test-warehouse"
+	cfg.WebAPI.Caching.Workers = 1
+	cfg.WebAPI.Caching.ResyncInterval.Duration = 5 * time.Second
+	err := SetConfig(&cfg)
+	assert.NoError(t, err)
+
+	pluginEntry := pluginmachinery.CreateRemotePlugin(newSnowflakeJobTaskPlugin())
+	plugin, err := pluginEntry.LoadPlugin(context.TODO(), newFakeSetupContext())
+	assert.NoError(t, err)
+
+	t.Run("SELECT 1", func(t *testing.T) {
+		queryJobConfig := QueryJobConfig{
+			Account:   "test-account",
+			Warehouse: "test-warehouse",
+			Schema:    "test-schema",
+			Database:  "test-database",
+			Statement: "SELECT 1",
+		}
+
+		inputs, _ := coreutils.MakeLiteralMap(map[string]interface{}{"x": 1})
+		custom, _ := pluginUtils.MarshalObjToStruct(queryJobConfig)
+		template := flyteIdlCore.TaskTemplate{
+			Type:   "snowflake",
+			Custom: custom,
+		}
+
+		phase := tests.RunPluginEndToEndTest(t, plugin, &template, inputs, nil, nil, iter)
+
+		assert.Equal(t, true, phase.Phase().IsSuccess())
+	})
+}
+
+func newFakeSnowflakeServer() *httptest.Server {
+	statementHandle := "019e7546-0000-278c-0000-40f10001a082"
+	return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/api/statements" && request.Method == "POST" {
+			writer.WriteHeader(202)
+			bytes := []byte(fmt.Sprintf(`{
+			  "statementHandle": "%v",
+			  "message": "Asynchronous execution in progress."
+			}`, statementHandle))
+			_, _ = writer.Write(bytes)
+			return
+		}
+
+		if request.URL.Path == "/api/statements/"+statementHandle && request.Method == "GET" {
+			writer.WriteHeader(200)
+			bytes := []byte(fmt.Sprintf(`{
+			  "statementHandle": "%v",
+			  "message": "Statement executed successfully."
+			}`, statementHandle))
+			_, _ = writer.Write(bytes)
+			return
+		}
+
+		if request.URL.Path == "/api/statements/"+statementHandle+"/cancel" && request.Method == "POST" {
+			writer.WriteHeader(200)
+			return
+		}
+
+		writer.WriteHeader(500)
+	}))
+}
+
+func newFakeSetupContext() *pluginCoreMocks.SetupContext {
+	fakeResourceRegistrar := pluginCoreMocks.ResourceRegistrar{}
+	fakeResourceRegistrar.On("RegisterResourceQuota", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	labeled.SetMetricKeys(contextutils.NamespaceKey)
+
+	fakeSetupContext := pluginCoreMocks.SetupContext{}
+	fakeSetupContext.OnMetricsScope().Return(promutils.NewScope("test"))
+	fakeSetupContext.OnResourceRegistrar().Return(&fakeResourceRegistrar)
+
+	return &fakeSetupContext
+}

--- a/go/tasks/plugins/webapi/snowflake/integration_test.go
+++ b/go/tasks/plugins/webapi/snowflake/integration_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	coreIdl "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+	pluginsIdl "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
+
 	"github.com/flyteorg/flyteidl/clients/go/coreutils"
 	flyteIdlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery"
@@ -43,19 +46,19 @@ func TestEndToEnd(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("SELECT 1", func(t *testing.T) {
-		queryJobConfig := QueryJobConfig{
+		snowflakeQuery := pluginsIdl.SnowflakeQuery{
 			Account:   "test-account",
 			Warehouse: "test-warehouse",
 			Schema:    "test-schema",
 			Database:  "test-database",
-			Statement: "SELECT 1",
 		}
 
 		inputs, _ := coreutils.MakeLiteralMap(map[string]interface{}{"x": 1})
-		custom, _ := pluginUtils.MarshalObjToStruct(queryJobConfig)
+		custom, _ := pluginUtils.MarshalObjToStruct(snowflakeQuery)
 		template := flyteIdlCore.TaskTemplate{
 			Type:   "snowflake",
 			Custom: custom,
+			Target: &coreIdl.TaskTemplate_Sql{Sql: &coreIdl.Sql{Statement: "SELECT 1", Dialect: coreIdl.Sql_ANSI}},
 		}
 
 		phase := tests.RunPluginEndToEndTest(t, plugin, &template, inputs, nil, nil, iter)

--- a/go/tasks/plugins/webapi/snowflake/integration_test.go
+++ b/go/tasks/plugins/webapi/snowflake/integration_test.go
@@ -8,15 +8,12 @@ import (
 	"testing"
 	"time"
 
-	coreIdl "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-	pluginsIdl "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
-
 	"github.com/flyteorg/flyteidl/clients/go/coreutils"
+	coreIdl "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	flyteIdlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery"
 	pluginCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	pluginCoreMocks "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
-	pluginUtils "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flyteplugins/tests"
 	"github.com/flyteorg/flytestdlib/contextutils"
 	"github.com/flyteorg/flytestdlib/promutils"
@@ -46,18 +43,16 @@ func TestEndToEnd(t *testing.T) {
 	assert.NoError(t, err)
 
 	t.Run("SELECT 1", func(t *testing.T) {
-		snowflakeQuery := pluginsIdl.SnowflakeQuery{
-			Account:   "test-account",
-			Warehouse: "test-warehouse",
-			Schema:    "test-schema",
-			Database:  "test-database",
-		}
+		config := make(map[string]string)
+		config["database"] = "my-database"
+		config["account"] = "snowflake"
+		config["schema"] = "my-schema"
+		config["warehouse"] = "my-warehouse"
 
 		inputs, _ := coreutils.MakeLiteralMap(map[string]interface{}{"x": 1})
-		custom, _ := pluginUtils.MarshalObjToStruct(snowflakeQuery)
 		template := flyteIdlCore.TaskTemplate{
 			Type:   "snowflake",
-			Custom: custom,
+			Config: config,
 			Target: &coreIdl.TaskTemplate_Sql{Sql: &coreIdl.Sql{Statement: "SELECT 1", Dialect: coreIdl.Sql_ANSI}},
 		}
 

--- a/go/tasks/plugins/webapi/snowflake/plugin.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin.go
@@ -251,7 +251,7 @@ func createTaskInfo(queryID string, account string) *core.TaskInfo {
 		OccurredAt: &timeNow,
 		Logs: []*flyteIdlCore.TaskLog{
 			{
-				Uri: fmt.Sprintf("https://%v.snowflakecomputing.com/console#/monitoring/queries/detail?queryID=%v",
+				Uri: fmt.Sprintf("https://%v.snowflakecomputing.com/console#/monitoring/queries/detail?queryId=%v",
 					account,
 					queryID),
 				Name: "Snowflake Console",

--- a/go/tasks/plugins/webapi/snowflake/plugin.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin.go
@@ -1,0 +1,286 @@
+package snowflake
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	flyteIdlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+	pluginErrors "github.com/flyteorg/flyteplugins/go/tasks/errors"
+	pluginsCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/template"
+	pluginUtils "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
+	"github.com/flyteorg/flytestdlib/errors"
+	"github.com/flyteorg/flytestdlib/logger"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/flyteorg/flytestdlib/promutils"
+
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi"
+)
+
+const (
+	ErrUser   errors.ErrorCode = "User"
+	ErrSystem errors.ErrorCode = "System"
+)
+
+type Plugin struct {
+	metricScope    promutils.Scope
+	cfg            *Config
+	snowflakeToken string
+}
+
+type ResourceWrapper struct {
+	Status  string
+	Message string
+}
+
+type ResourceMetaWrapper struct {
+	QueryID string
+	Account string
+}
+
+func (p Plugin) GetConfig() webapi.PluginConfig {
+	return GetConfig().WebAPI
+}
+
+type QueryInfo struct {
+	Account   string
+	Warehouse string
+	Schema    string
+	Database  string
+	Statement string
+}
+
+// TODO: Add QueryJobConfig in Flyteidl
+type QueryJobConfig struct {
+	Account   string `json:"account"`
+	Warehouse string `json:"warehouse"`
+	Schema    string `json:"schema"`
+	Database  string `json:"database"`
+	Statement string `json:"statement"`
+}
+
+func (p Plugin) ResourceRequirements(_ context.Context, _ webapi.TaskExecutionContextReader) (
+	namespace core.ResourceNamespace, constraints core.ResourceConstraintsSpec, err error) {
+
+	// Resource requirements are assumed to be the same.
+	return "default", p.cfg.ResourceConstraints, nil
+}
+
+func (p Plugin) Create(ctx context.Context, taskCtx webapi.TaskExecutionContextReader) (webapi.ResourceMeta,
+	webapi.Resource, error) {
+	task, err := taskCtx.TaskReader().Read(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	custom := task.GetCustom()
+	snowflakeQuery := QueryJobConfig{}
+	err = pluginUtils.UnmarshalStructToObj(custom, &snowflakeQuery)
+	if err != nil {
+		return nil, nil, errors.Wrapf(ErrUser, err, "Expects a valid PrestoQuery proto in custom field.")
+	}
+	outputs, err := template.Render(ctx, []string{
+		snowflakeQuery.Account,
+		snowflakeQuery.Warehouse,
+		snowflakeQuery.Schema,
+		snowflakeQuery.Database,
+		snowflakeQuery.Statement,
+	}, template.Parameters{
+		TaskExecMetadata: taskCtx.TaskExecutionMetadata(),
+		Inputs:           taskCtx.InputReader(),
+		OutputPath:       taskCtx.OutputWriter(),
+		Task:             taskCtx.TaskReader(),
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	queryInfo := QueryInfo{
+		Account:   outputs[0],
+		Warehouse: outputs[1],
+		Schema:    outputs[2],
+		Database:  outputs[3],
+		Statement: outputs[4],
+	}
+
+	if len(queryInfo.Warehouse) == 0 {
+		queryInfo.Warehouse = p.cfg.DefaultWarehouse
+	}
+
+	if len(queryInfo.Warehouse) == 0 {
+		queryInfo.Warehouse = p.cfg.DefaultWarehouse
+	}
+	req, err := buildRequest("POST", queryInfo, queryInfo.Account, p.snowflakeToken, "", false)
+	if err != nil {
+		return nil, nil, err
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer resp.Body.Close()
+	data, err := buildResponse(resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	queryId := fmt.Sprintf("%v", data["statementHandle"])
+	message := fmt.Sprintf("%v", data["message"])
+
+	return ResourceMetaWrapper{queryId, queryInfo.Account},
+		ResourceWrapper{Status: resp.Status, Message: message}, nil
+}
+
+func (p Plugin) Get(ctx context.Context, taskCtx webapi.GetContext) (latest webapi.Resource, err error) {
+	exec := taskCtx.ResourceMeta().(*ResourceMetaWrapper)
+	req, err := buildRequest("GET", QueryInfo{}, exec.Account, p.snowflakeToken, exec.QueryID, false)
+	if err != nil {
+		return nil, err
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	data, err := buildResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+	message := fmt.Sprintf("%v", data["message"])
+	return ResourceWrapper{
+		Status:  resp.Status,
+		Message: message,
+	}, nil
+}
+
+func (p Plugin) Delete(ctx context.Context, taskCtx webapi.DeleteContext) error {
+	exec := taskCtx.ResourceMeta().(*ResourceMetaWrapper)
+	req, err := buildRequest("POST", QueryInfo{}, exec.Account, p.snowflakeToken, exec.QueryID, true)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	logger.Info(ctx, "Deleted query execution [%v]", resp)
+
+	return nil
+}
+
+func (p Plugin) Status(_ context.Context, taskCtx webapi.StatusContext) (phase core.PhaseInfo, err error) {
+	exec := taskCtx.ResourceMeta().(*ResourceMetaWrapper)
+	status := taskCtx.Resource().(*ResourceWrapper).Status
+	if status == "" {
+		return core.PhaseInfoUndefined, errors.Errorf(ErrSystem, "No Status field set.")
+	}
+	statusCode, err := strconv.Atoi(status)
+	if err != nil {
+		return core.PhaseInfoUndefined, pluginErrors.Errorf(pluginsCore.SystemErrorCode, "unknown execution phase [%v].", status)
+	}
+	taskInfo := createTaskInfo(exec.QueryID, exec.Account)
+	switch statusCode {
+	case http.StatusAccepted:
+		return core.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, createTaskInfo(exec.QueryID, exec.Account)), nil
+	case http.StatusOK:
+		return pluginsCore.PhaseInfoSuccess(taskInfo), nil
+	case http.StatusUnprocessableEntity:
+		return pluginsCore.PhaseInfoFailure(status, "phaseReason", taskInfo), nil
+	}
+	return core.PhaseInfoUndefined, pluginErrors.Errorf(pluginsCore.SystemErrorCode, "unknown execution phase [%v].", status)
+}
+
+func buildRequest(method string, queryInfo QueryInfo, account string, token string,
+	queryId string, isCancel bool) (*http.Request, error) {
+	snowflakeUrl := "https://" + account + ".snowflakecomputing.com/api/statements"
+	var data []byte
+	if method == "POST" && !isCancel {
+		snowflakeUrl += "?async=true"
+		data = []byte(fmt.Sprintf(`{
+		  "statement": "%v",
+		  "database": "%v",
+		  "schema": "%v",
+		  "warehouse": "%v"
+		}`, queryInfo.Statement, queryInfo.Database, queryInfo.Schema, queryInfo.Warehouse))
+	} else {
+		snowflakeUrl += "/" + queryId
+	}
+	if isCancel {
+		snowflakeUrl += "/cancel"
+	}
+
+	req, err := http.NewRequest(method, snowflakeUrl, bytes.NewBuffer(data))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", "Bearer "+token)
+	req.Header.Add("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT")
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+	return req, nil
+}
+
+func buildResponse(response *http.Response) (map[string]interface{}, error) {
+	responseBody, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return nil, err
+	}
+	var data map[string]interface{}
+	err = json.Unmarshal(responseBody, &data)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func createTaskInfo(queryId string, account string) *core.TaskInfo {
+	timeNow := time.Now()
+
+	return &core.TaskInfo{
+		OccurredAt: &timeNow,
+		Logs: []*flyteIdlCore.TaskLog{
+			{
+				Uri: fmt.Sprintf("https://%v.snowflakecomputing.com/console#/monitoring/queries/detail?queryId=%v",
+					account,
+					queryId),
+				Name: "Snowflake Console",
+			},
+		},
+	}
+}
+
+func getSnowflakeToken() string {
+	return os.Getenv("SNOWFLAKE_TOKEN")
+}
+
+func newSnowflakeJobTaskPlugin() webapi.PluginEntry {
+	return webapi.PluginEntry{
+		ID:                 "snowflake",
+		SupportedTaskTypes: []core.TaskType{"snowflake"},
+		PluginLoader: func(ctx context.Context, iCtx webapi.PluginSetupContext) (webapi.AsyncPlugin, error) {
+			return &Plugin{
+				metricScope:    iCtx.MetricsScope(),
+				cfg:            GetConfig(),
+				snowflakeToken: getSnowflakeToken(),
+			}, nil
+		},
+	}
+}
+
+func init() {
+	gob.Register(ResourceMetaWrapper{})
+	gob.Register(ResourceWrapper{})
+
+	pluginmachinery.PluginRegistry().RegisterRemotePlugin(newSnowflakeJobTaskPlugin())
+}

--- a/go/tasks/plugins/webapi/snowflake/plugin.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin.go
@@ -132,10 +132,10 @@ func (p Plugin) Create(ctx context.Context, taskCtx webapi.TaskExecutionContextR
 	if err != nil {
 		return nil, nil, err
 	}
-	queryId := fmt.Sprintf("%v", data["statementHandle"])
+	queryID := fmt.Sprintf("%v", data["statementHandle"])
 	message := fmt.Sprintf("%v", data["message"])
 
-	return ResourceMetaWrapper{queryId, queryInfo.Account},
+	return ResourceMetaWrapper{queryID, queryInfo.Account},
 		ResourceWrapper{Status: resp.Status, Message: message}, nil
 }
 
@@ -202,11 +202,11 @@ func (p Plugin) Status(_ context.Context, taskCtx webapi.StatusContext) (phase c
 }
 
 func buildRequest(method string, queryInfo QueryInfo, account string, token string,
-	queryId string, isCancel bool) (*http.Request, error) {
-	snowflakeUrl := "https://" + account + ".snowflakecomputing.com/api/statements"
+	queryID string, isCancel bool) (*http.Request, error) {
+	snowflakeURL := "https://" + account + ".snowflakecomputing.com/api/statements"
 	var data []byte
 	if method == "POST" && !isCancel {
-		snowflakeUrl += "?async=true"
+		snowflakeURL += "?async=true"
 		data = []byte(fmt.Sprintf(`{
 		  "statement": "%v",
 		  "database": "%v",
@@ -214,13 +214,13 @@ func buildRequest(method string, queryInfo QueryInfo, account string, token stri
 		  "warehouse": "%v"
 		}`, queryInfo.Statement, queryInfo.Database, queryInfo.Schema, queryInfo.Warehouse))
 	} else {
-		snowflakeUrl += "/" + queryId
+		snowflakeURL += "/" + queryID
 	}
 	if isCancel {
-		snowflakeUrl += "/cancel"
+		snowflakeURL += "/cancel"
 	}
 
-	req, err := http.NewRequest(method, snowflakeUrl, bytes.NewBuffer(data))
+	req, err := http.NewRequest(method, snowflakeURL, bytes.NewBuffer(data))
 	if err != nil {
 		return nil, err
 	}
@@ -244,16 +244,16 @@ func buildResponse(response *http.Response) (map[string]interface{}, error) {
 	return data, nil
 }
 
-func createTaskInfo(queryId string, account string) *core.TaskInfo {
+func createTaskInfo(queryID string, account string) *core.TaskInfo {
 	timeNow := time.Now()
 
 	return &core.TaskInfo{
 		OccurredAt: &timeNow,
 		Logs: []*flyteIdlCore.TaskLog{
 			{
-				Uri: fmt.Sprintf("https://%v.snowflakecomputing.com/console#/monitoring/queries/detail?queryId=%v",
+				Uri: fmt.Sprintf("https://%v.snowflakecomputing.com/console#/monitoring/queries/detail?queryID=%v",
 					account,
-					queryId),
+					queryID),
 				Name: "Snowflake Console",
 			},
 		},

--- a/go/tasks/plugins/webapi/snowflake/plugin.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin.go
@@ -115,10 +115,6 @@ func (p Plugin) Create(ctx context.Context, taskCtx webapi.TaskExecutionContextR
 	if len(queryInfo.Warehouse) == 0 {
 		queryInfo.Warehouse = p.cfg.DefaultWarehouse
 	}
-
-	if len(queryInfo.Warehouse) == 0 {
-		queryInfo.Warehouse = p.cfg.DefaultWarehouse
-	}
 	req, err := buildRequest("POST", queryInfo, queryInfo.Account, p.snowflakeToken, "", false)
 	if err != nil {
 		return nil, nil, err

--- a/go/tasks/plugins/webapi/snowflake/plugin.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin.go
@@ -6,6 +6,12 @@ import (
 	"encoding/gob"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
 	flyteIdlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	pluginErrors "github.com/flyteorg/flyteplugins/go/tasks/errors"
 	pluginsCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
@@ -13,11 +19,6 @@ import (
 	pluginUtils "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flytestdlib/errors"
 	"github.com/flyteorg/flytestdlib/logger"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"strconv"
-	"time"
 
 	"github.com/flyteorg/flytestdlib/promutils"
 

--- a/go/tasks/plugins/webapi/snowflake/plugin_test.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin_test.go
@@ -1,0 +1,80 @@
+package snowflake
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestCreateTaskInfo(t *testing.T) {
+	t.Run("create task info", func(t *testing.T) {
+		taskInfo := createTaskInfo("d5493e36", "test-account")
+
+		assert.Equal(t, 1, len(taskInfo.Logs))
+		assert.Equal(t, taskInfo.Logs[0].Uri, "https://test-account.snowflakecomputing.com/console#/monitoring/queries/detail?queryId=d5493e36")
+		assert.Equal(t, taskInfo.Logs[0].Name, "Snowflake Console")
+	})
+}
+
+func TestBuildRequest(t *testing.T) {
+	account := "test-account"
+	token := "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9"
+	queryId := "019e70eb-0000-278b-0000-40f100012b1a"
+	snowflakeUrl := "https://" + account + ".snowflakecomputing.com/api/statements"
+	t.Run("build http request for submitting a snowflake query", func(t *testing.T) {
+		queryInfo := QueryInfo{
+			Account:   account,
+			Warehouse: "test-warehouse",
+			Schema:    "test-schema",
+			Database:  "test-database",
+			Statement: "SELECT 1",
+		}
+
+		req, err := buildRequest("POST", queryInfo, account, token, queryId, false)
+		header := http.Header{}
+		header.Add("Authorization", "Bearer "+token)
+		header.Add("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT")
+		header.Add("Content-Type", "application/json")
+		header.Add("Accept", "application/json")
+
+		assert.NoError(t, err)
+		assert.Equal(t, header, req.Header)
+		assert.Equal(t, snowflakeUrl+"?async=true", req.URL.String())
+		assert.Equal(t, "POST", req.Method)
+	})
+	t.Run("build http request for getting a snowflake query status", func(t *testing.T) {
+		req, err := buildRequest("GET", QueryInfo{}, account, token, queryId, false)
+
+		assert.NoError(t, err)
+		assert.Equal(t, snowflakeUrl+"/"+queryId, req.URL.String())
+		assert.Equal(t, "GET", req.Method)
+	})
+	t.Run("build http request for deleting a snowflake query", func(t *testing.T) {
+		req, err := buildRequest("POST", QueryInfo{}, account, token, queryId, true)
+
+		assert.NoError(t, err)
+		assert.Equal(t, snowflakeUrl+"/"+queryId+"/cancel", req.URL.String())
+		assert.Equal(t, "POST", req.Method)
+	})
+}
+
+func TestBuildResponse(t *testing.T) {
+	t.Run("build http response", func(t *testing.T) {
+		bodyStr := `{"data":{"statementHandle":"019c06a4-0000","message":"Statement executed successfully."}}`
+		responseBody := io.NopCloser(strings.NewReader(bodyStr))
+		response := &http.Response{Body: responseBody}
+		actualData, err := buildResponse(response)
+		assert.NoError(t, err)
+
+		bodyByte, err := ioutil.ReadAll(strings.NewReader(bodyStr))
+		assert.NoError(t, err)
+		var expectedData map[string]interface{}
+		err = json.Unmarshal(bodyByte, &expectedData)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedData, actualData)
+	})
+}

--- a/go/tasks/plugins/webapi/snowflake/plugin_test.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin_test.go
@@ -2,11 +2,12 @@ package snowflake
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateTaskInfo(t *testing.T) {
@@ -21,9 +22,9 @@ func TestCreateTaskInfo(t *testing.T) {
 
 func TestBuildRequest(t *testing.T) {
 	account := "test-account"
-	dummyToken := "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9"
+	token := getSnowflakeToken()
 	queryID := "019e70eb-0000-278b-0000-40f100012b1a"
-	snowflakeUrl := "https://" + account + ".snowflakecomputing.com/api/statements"
+	snowflakeURL := "https://" + account + ".snowflakecomputing.com/api/statements"
 	t.Run("build http request for submitting a snowflake query", func(t *testing.T) {
 		queryInfo := QueryInfo{
 			Account:   account,
@@ -33,30 +34,30 @@ func TestBuildRequest(t *testing.T) {
 			Statement: "SELECT 1",
 		}
 
-		req, err := buildRequest("POST", queryInfo, account, dummyToken, queryID, false)
+		req, err := buildRequest("POST", queryInfo, account, token, queryID, false)
 		header := http.Header{}
-		header.Add("Authorization", "Bearer "+dummyToken)
+		header.Add("Authorization", "Bearer "+token)
 		header.Add("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT")
 		header.Add("Content-Type", "application/json")
 		header.Add("Accept", "application/json")
 
 		assert.NoError(t, err)
 		assert.Equal(t, header, req.Header)
-		assert.Equal(t, snowflakeUrl+"?async=true", req.URL.String())
+		assert.Equal(t, snowflakeURL+"?async=true", req.URL.String())
 		assert.Equal(t, "POST", req.Method)
 	})
 	t.Run("build http request for getting a snowflake query status", func(t *testing.T) {
-		req, err := buildRequest("GET", QueryInfo{}, account, dummyToken, queryID, false)
+		req, err := buildRequest("GET", QueryInfo{}, account, token, queryID, false)
 
 		assert.NoError(t, err)
-		assert.Equal(t, snowflakeUrl+"/"+queryID, req.URL.String())
+		assert.Equal(t, snowflakeURL+"/"+queryID, req.URL.String())
 		assert.Equal(t, "GET", req.Method)
 	})
 	t.Run("build http request for deleting a snowflake query", func(t *testing.T) {
-		req, err := buildRequest("POST", QueryInfo{}, account, dummyToken, queryID, true)
+		req, err := buildRequest("POST", QueryInfo{}, account, token, queryID, true)
 
 		assert.NoError(t, err)
-		assert.Equal(t, snowflakeUrl+"/"+queryID+"/cancel", req.URL.String())
+		assert.Equal(t, snowflakeURL+"/"+queryID+"/cancel", req.URL.String())
 		assert.Equal(t, "POST", req.Method)
 	})
 }

--- a/go/tasks/plugins/webapi/snowflake/plugin_test.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin_test.go
@@ -3,7 +3,6 @@ package snowflake
 import (
 	"encoding/json"
 	"github.com/stretchr/testify/assert"
-	"io"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -65,7 +64,7 @@ func TestBuildRequest(t *testing.T) {
 func TestBuildResponse(t *testing.T) {
 	t.Run("build http response", func(t *testing.T) {
 		bodyStr := `{"data":{"statementHandle":"019c06a4-0000","message":"Statement executed successfully."}}`
-		responseBody := io.NopCloser(strings.NewReader(bodyStr))
+		responseBody := ioutil.NopCloser(strings.NewReader(bodyStr))
 		response := &http.Response{Body: responseBody}
 		actualData, err := buildResponse(response)
 		assert.NoError(t, err)

--- a/go/tasks/plugins/webapi/snowflake/plugin_test.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin_test.go
@@ -9,14 +9,10 @@ import (
 	"testing"
 	"time"
 
-	pluginsIdl "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
-
 	pluginsCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	pluginCoreMocks "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
-	pluginUtils "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type MockClient struct {
@@ -62,28 +58,6 @@ func TestCreateTaskInfo(t *testing.T) {
 		assert.Equal(t, 1, len(taskInfo.Logs))
 		assert.Equal(t, taskInfo.Logs[0].Uri, "https://test-account.snowflakecomputing.com/console#/monitoring/queries/detail?queryId=d5493e36")
 		assert.Equal(t, taskInfo.Logs[0].Name, "Snowflake Console")
-	})
-}
-
-func TestUnmarshalSnowflakeQueryConfig(t *testing.T) {
-	custom := structpb.Struct{
-		Fields: map[string]*structpb.Value{
-			"Account":   structpb.NewStringValue("test-account"),
-			"Warehouse": structpb.NewStringValue("test-warehouse"),
-			"Schema":    structpb.NewStringValue("test-schema"),
-			"Database":  structpb.NewStringValue("test-database"),
-		},
-	}
-
-	snowflakeQuery := pluginsIdl.SnowflakeQuery{}
-	err := pluginUtils.UnmarshalStructToObj(&custom, &snowflakeQuery)
-	assert.NoError(t, err)
-
-	assert.Equal(t, snowflakeQuery, pluginsIdl.SnowflakeQuery{
-		Account:   "test-account",
-		Warehouse: "test-warehouse",
-		Schema:    "test-schema",
-		Database:  "test-database",
 	})
 }
 

--- a/go/tasks/plugins/webapi/snowflake/plugin_test.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin_test.go
@@ -79,6 +79,7 @@ func TestBuildRequest(t *testing.T) {
 	account := "test-account"
 	token := getSnowflakeToken()
 	queryID := "019e70eb-0000-278b-0000-40f100012b1a"
+	snowflakeEndpoint := ""
 	snowflakeURL := "https://" + account + ".snowflakecomputing.com/api/statements"
 	t.Run("build http request for submitting a snowflake query", func(t *testing.T) {
 		queryInfo := QueryInfo{
@@ -89,7 +90,7 @@ func TestBuildRequest(t *testing.T) {
 			Statement: "SELECT 1",
 		}
 
-		req, err := buildRequest("POST", queryInfo, account, token, queryID, false)
+		req, err := buildRequest("POST", queryInfo, snowflakeEndpoint, account, token, queryID, false)
 		header := http.Header{}
 		header.Add("Authorization", "Bearer "+token)
 		header.Add("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT")
@@ -102,14 +103,14 @@ func TestBuildRequest(t *testing.T) {
 		assert.Equal(t, "POST", req.Method)
 	})
 	t.Run("build http request for getting a snowflake query status", func(t *testing.T) {
-		req, err := buildRequest("GET", QueryInfo{}, account, token, queryID, false)
+		req, err := buildRequest("GET", QueryInfo{}, snowflakeEndpoint, account, token, queryID, false)
 
 		assert.NoError(t, err)
 		assert.Equal(t, snowflakeURL+"/"+queryID, req.URL.String())
 		assert.Equal(t, "GET", req.Method)
 	})
 	t.Run("build http request for deleting a snowflake query", func(t *testing.T) {
-		req, err := buildRequest("POST", QueryInfo{}, account, token, queryID, true)
+		req, err := buildRequest("POST", QueryInfo{}, snowflakeEndpoint, account, token, queryID, true)
 
 		assert.NoError(t, err)
 		assert.Equal(t, snowflakeURL+"/"+queryID+"/cancel", req.URL.String())

--- a/go/tasks/plugins/webapi/snowflake/plugin_test.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin_test.go
@@ -33,10 +33,9 @@ func TestPlugin(t *testing.T) {
 	fakeSetupContext.OnMetricsScope().Return(promutils.NewScope("test"))
 
 	plugin := Plugin{
-		metricScope:    fakeSetupContext.MetricsScope(),
-		cfg:            GetConfig(),
-		client:         &MockClient{},
-		snowflakeToken: getSnowflakeToken(),
+		metricScope: fakeSetupContext.MetricsScope(),
+		cfg:         GetConfig(),
+		client:      &MockClient{},
 	}
 	t.Run("get config", func(t *testing.T) {
 		cfg := defaultConfig
@@ -90,7 +89,7 @@ func TestUnmarshalSnowflakeQueryConfig(t *testing.T) {
 
 func TestBuildRequest(t *testing.T) {
 	account := "test-account"
-	token := getSnowflakeToken()
+	token := "test-token"
 	queryID := "019e70eb-0000-278b-0000-40f100012b1a"
 	snowflakeEndpoint := ""
 	snowflakeURL := "https://" + account + ".snowflakecomputing.com/api/statements"
@@ -103,7 +102,7 @@ func TestBuildRequest(t *testing.T) {
 			Statement: "SELECT 1",
 		}
 
-		req, err := buildRequest("POST", queryInfo, snowflakeEndpoint, account, token, queryID, false)
+		req, err := buildRequest(post, queryInfo, snowflakeEndpoint, account, token, queryID, false)
 		header := http.Header{}
 		header.Add("Authorization", "Bearer "+token)
 		header.Add("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT")
@@ -113,21 +112,21 @@ func TestBuildRequest(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, header, req.Header)
 		assert.Equal(t, snowflakeURL+"?async=true", req.URL.String())
-		assert.Equal(t, "POST", req.Method)
+		assert.Equal(t, post, req.Method)
 	})
 	t.Run("build http request for getting a snowflake query status", func(t *testing.T) {
-		req, err := buildRequest("GET", QueryInfo{}, snowflakeEndpoint, account, token, queryID, false)
+		req, err := buildRequest(get, QueryInfo{}, snowflakeEndpoint, account, token, queryID, false)
 
 		assert.NoError(t, err)
 		assert.Equal(t, snowflakeURL+"/"+queryID, req.URL.String())
-		assert.Equal(t, "GET", req.Method)
+		assert.Equal(t, get, req.Method)
 	})
 	t.Run("build http request for deleting a snowflake query", func(t *testing.T) {
-		req, err := buildRequest("POST", QueryInfo{}, snowflakeEndpoint, account, token, queryID, true)
+		req, err := buildRequest(post, QueryInfo{}, snowflakeEndpoint, account, token, queryID, true)
 
 		assert.NoError(t, err)
 		assert.Equal(t, snowflakeURL+"/"+queryID+"/cancel", req.URL.String())
-		assert.Equal(t, "POST", req.Method)
+		assert.Equal(t, post, req.Method)
 	})
 }
 

--- a/go/tasks/plugins/webapi/snowflake/plugin_test.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin_test.go
@@ -21,8 +21,8 @@ func TestCreateTaskInfo(t *testing.T) {
 
 func TestBuildRequest(t *testing.T) {
 	account := "test-account"
-	token := "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9"
-	queryId := "019e70eb-0000-278b-0000-40f100012b1a"
+	dummyToken := "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9"
+	queryID := "019e70eb-0000-278b-0000-40f100012b1a"
 	snowflakeUrl := "https://" + account + ".snowflakecomputing.com/api/statements"
 	t.Run("build http request for submitting a snowflake query", func(t *testing.T) {
 		queryInfo := QueryInfo{
@@ -33,9 +33,9 @@ func TestBuildRequest(t *testing.T) {
 			Statement: "SELECT 1",
 		}
 
-		req, err := buildRequest("POST", queryInfo, account, token, queryId, false)
+		req, err := buildRequest("POST", queryInfo, account, dummyToken, queryID, false)
 		header := http.Header{}
-		header.Add("Authorization", "Bearer "+token)
+		header.Add("Authorization", "Bearer "+dummyToken)
 		header.Add("X-Snowflake-Authorization-Token-Type", "KEYPAIR_JWT")
 		header.Add("Content-Type", "application/json")
 		header.Add("Accept", "application/json")
@@ -46,17 +46,17 @@ func TestBuildRequest(t *testing.T) {
 		assert.Equal(t, "POST", req.Method)
 	})
 	t.Run("build http request for getting a snowflake query status", func(t *testing.T) {
-		req, err := buildRequest("GET", QueryInfo{}, account, token, queryId, false)
+		req, err := buildRequest("GET", QueryInfo{}, account, dummyToken, queryID, false)
 
 		assert.NoError(t, err)
-		assert.Equal(t, snowflakeUrl+"/"+queryId, req.URL.String())
+		assert.Equal(t, snowflakeUrl+"/"+queryID, req.URL.String())
 		assert.Equal(t, "GET", req.Method)
 	})
 	t.Run("build http request for deleting a snowflake query", func(t *testing.T) {
-		req, err := buildRequest("POST", QueryInfo{}, account, token, queryId, true)
+		req, err := buildRequest("POST", QueryInfo{}, account, dummyToken, queryID, true)
 
 		assert.NoError(t, err)
-		assert.Equal(t, snowflakeUrl+"/"+queryId+"/cancel", req.URL.String())
+		assert.Equal(t, snowflakeUrl+"/"+queryID+"/cancel", req.URL.String())
 		assert.Equal(t, "POST", req.Method)
 	})
 }

--- a/go/tasks/plugins/webapi/snowflake/plugin_test.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	pluginsIdl "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
+
 	pluginsCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	pluginCoreMocks "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 	pluginUtils "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
@@ -70,20 +72,18 @@ func TestUnmarshalSnowflakeQueryConfig(t *testing.T) {
 			"Warehouse": structpb.NewStringValue("test-warehouse"),
 			"Schema":    structpb.NewStringValue("test-schema"),
 			"Database":  structpb.NewStringValue("test-database"),
-			"Statement": structpb.NewStringValue("SELECT 1"),
 		},
 	}
 
-	prestoQuery := QueryJobConfig{}
-	err := pluginUtils.UnmarshalStructToObj(&custom, &prestoQuery)
+	snowflakeQuery := pluginsIdl.SnowflakeQuery{}
+	err := pluginUtils.UnmarshalStructToObj(&custom, &snowflakeQuery)
 	assert.NoError(t, err)
 
-	assert.Equal(t, prestoQuery, QueryJobConfig{
+	assert.Equal(t, snowflakeQuery, pluginsIdl.SnowflakeQuery{
 		Account:   "test-account",
 		Warehouse: "test-warehouse",
 		Schema:    "test-schema",
 		Database:  "test-database",
-		Statement: "SELECT 1",
 	})
 }
 

--- a/go/tasks/plugins/webapi/snowflake/plugin_test.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin_test.go
@@ -9,7 +9,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	mocks3 "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io/mocks"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi/mocks"
+	"github.com/flyteorg/flytestdlib/utils"
+
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+	pluginsCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	mocks2 "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 	pluginCoreMocks "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 	pluginUtils "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
 	"github.com/flyteorg/flytestdlib/promutils"
@@ -17,22 +23,26 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
-func TestCreateTaskInfo(t *testing.T) {
-	t.Run("create task info", func(t *testing.T) {
-		taskInfo := createTaskInfo("d5493e36", "test-account")
+type MockClient struct {
+}
 
-		assert.Equal(t, 1, len(taskInfo.Logs))
-		assert.Equal(t, taskInfo.Logs[0].Uri, "https://test-account.snowflakecomputing.com/console#/monitoring/queries/detail?queryId=d5493e36")
-		assert.Equal(t, taskInfo.Logs[0].Name, "Snowflake Console")
-	})
+var (
+	MockDo func(req *http.Request) (*http.Response, error)
+)
+
+func (m *MockClient) Do(req *http.Request) (*http.Response, error) {
+	return MockDo(req)
 }
 
 func TestPlugin(t *testing.T) {
+	ctx := context.Background()
 	fakeSetupContext := pluginCoreMocks.SetupContext{}
 	fakeSetupContext.OnMetricsScope().Return(promutils.NewScope("test"))
+
 	plugin := Plugin{
 		metricScope:    fakeSetupContext.MetricsScope(),
 		cfg:            GetConfig(),
+		client:         &MockClient{},
 		snowflakeToken: getSnowflakeToken(),
 	}
 	t.Run("get config", func(t *testing.T) {
@@ -46,8 +56,87 @@ func TestPlugin(t *testing.T) {
 	t.Run("get ResourceRequirements", func(t *testing.T) {
 		namespace, constraints, err := plugin.ResourceRequirements(context.TODO(), nil)
 		assert.NoError(t, err)
-		assert.Equal(t, core.ResourceNamespace("default"), namespace)
+		assert.Equal(t, pluginsCore.ResourceNamespace("default"), namespace)
 		assert.Equal(t, plugin.cfg.ResourceConstraints, constraints)
+	})
+	t.Run("create snowflake query", func(t *testing.T) {
+		tCtx := &mocks.TaskExecutionContextReader{}
+		taskReader := &mocks2.TaskReader{}
+		queryInfo := QueryInfo{
+			Account:   "test-account",
+			Warehouse: "test-warehouse",
+			Schema:    "test-schema",
+			Database:  "test-database",
+			Statement: "SELECT 1",
+		}
+		st, err := utils.MarshalObjToStruct(queryInfo)
+		if !assert.NoError(t, err) {
+			assert.FailNowf(t, "expected to be able to marshal", "")
+		}
+
+		taskReader.OnRead(ctx).Return(&core.TaskTemplate{
+			Interface: &core.TypedInterface{
+				Outputs: &core.VariableMap{
+					Variables: map[string]*core.Variable{
+						"results": {
+							Type: &core.LiteralType{
+								Type: &core.LiteralType_Schema{
+									Schema: &core.SchemaType{
+										Columns: []*core.SchemaType_SchemaColumn{},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Custom: st,
+		}, nil)
+
+		tCtx.OnTaskReader().Return(taskReader)
+
+		tMeta := &mocks2.TaskExecutionMetadata{}
+		tCtx.OnTaskExecutionMetadata().Return(tMeta)
+
+		tID := &mocks2.TaskExecutionID{}
+		tMeta.OnGetTaskExecutionID().Return(tID)
+
+		tID.OnGetGeneratedName().Return("generated-name")
+
+		ow := &mocks3.OutputWriter{}
+		tCtx.OnOutputWriter().Return(ow)
+		ow.OnGetOutputPrefixPath().Return("s3://another")
+		ow.OnGetRawOutputPrefix().Return("s3://another/output")
+
+		ir := &mocks3.InputReader{}
+		tCtx.OnInputReader().Return(ir)
+		ir.OnGetInputPath().Return("s3://something")
+		ir.OnGetInputPrefixPath().Return("s3://something/2")
+		ir.OnGet(ctx).Return(nil, nil)
+
+		bodyStr := `{"statementHandle":"019c06a4-0000", "message":"Statement executed successfully."}`
+		responseBody := ioutil.NopCloser(strings.NewReader(bodyStr))
+		MockDo = func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 200,
+				Body:       responseBody,
+			}, nil
+		}
+
+		resourceMeta, resource, err := plugin.Create(context.TODO(), tCtx)
+		assert.NoError(t, err)
+		assert.Equal(t, &ResourceMetaWrapper{"019c06a4-0000", queryInfo.Account}, resourceMeta)
+		assert.Equal(t, &ResourceWrapper{200, "Statement executed successfully."}, resource)
+	})
+}
+
+func TestCreateTaskInfo(t *testing.T) {
+	t.Run("create task info", func(t *testing.T) {
+		taskInfo := createTaskInfo("d5493e36", "test-account")
+
+		assert.Equal(t, 1, len(taskInfo.Logs))
+		assert.Equal(t, taskInfo.Logs[0].Uri, "https://test-account.snowflakecomputing.com/console#/monitoring/queries/detail?queryId=d5493e36")
+		assert.Equal(t, taskInfo.Logs[0].Name, "Snowflake Console")
 	})
 }
 
@@ -120,7 +209,7 @@ func TestBuildRequest(t *testing.T) {
 
 func TestBuildResponse(t *testing.T) {
 	t.Run("build http response", func(t *testing.T) {
-		bodyStr := `{"data":{"statementHandle":"019c06a4-0000","message":"Statement executed successfully."}}`
+		bodyStr := `{"statementHandle":"019c06a4-0000", "message":"Statement executed successfully."}`
 		responseBody := ioutil.NopCloser(strings.NewReader(bodyStr))
 		response := &http.Response{Body: responseBody}
 		actualData, err := buildResponse(response)

--- a/tests/end_to_end.go
+++ b/tests/end_to_end.go
@@ -228,6 +228,9 @@ func RunPluginEndToEndTest(t *testing.T, executor pluginCore.Plugin, template *i
 	resourceManager.OnAllocateResourceMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(pluginCore.AllocationStatusGranted, nil)
 	resourceManager.OnReleaseResourceMatch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
+	secretManager := &coreMocks.SecretManager{}
+	secretManager.OnGet(ctx, mock.Anything).Return("fake-token", nil)
+
 	tCtx := &coreMocks.TaskExecutionContext{}
 	tCtx.OnInputReader().Return(inputReader)
 	tCtx.OnTaskRefreshIndicator().Return(func(ctx context.Context) {})
@@ -241,8 +244,7 @@ func RunPluginEndToEndTest(t *testing.T, executor pluginCore.Plugin, template *i
 	tCtx.OnEventsRecorder().Return(eRecorder)
 	tCtx.OnResourceManager().Return(resourceManager)
 	tCtx.OnMaxDatasetSizeBytes().Return(1000000)
-	// TODO: return that
-	tCtx.OnSecretManager()
+	tCtx.OnSecretManager().Return(secretManager)
 
 	trns := pluginCore.DoTransitionType(pluginCore.TransitionTypeBarrier, pluginCore.PhaseInfoQueued(time.Now(), 0, ""))
 	for !trns.Info().Phase().IsTerminal() {


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Implements WebAPI plugin for Snowflake.

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [x] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Any pending items have an associated Issue
 - [ ] Code documentation added

## Complete description
Use Snowflake Rest API instead of Golang API to implement the backend plugin since Snowflake Golang API doesn't have a function that cancels a query or gets query status by query ID.

And Snowflake Rest API only support client use `Oauth` or `JSON Web Token (JWT)` to authenticate to the server.
https://docs.snowflake.com/en/developer-guide/sql-api/guide.html#authenticating-to-the-server

If clients want to use `username` and `password` to authenticate to the server, they can use `SQLAlchemyTask`.
For example: 
```python
task_config=SQLAlchemyConfig(
        uri='snowflake://{user}:{password}@{account}/'.format(
            user='haytham',
            password='<your_password>',
            account='hoa61102',
        ),
```

Refer:
[Snowflake SQL API Reference](https://docs.snowflake.com/en/developer-guide/sql-api/reference.html#snowflake-sql-api-reference)
[Snowflake SQL API Developer Guide](https://docs.snowflake.com/en/developer-guide/sql-api/guide.html#authenticating-to-the-server)
[Snowflake Golang API](https://github.com/snowflakedb/gosnowflake)

## TODO
- [ ] Add example in Flytesnack
- [ ] Update Flyteidl
- [ ] Add Snowflake tasks in Flytekit

## Follow-up issue
_NA_