### PR TITLE
Fix flytek8s config DefaultAffinity being updated during UpdatePod

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -76,8 +76,8 @@ func UpdatePod(taskExecutionMetadata pluginsCore.TaskExecutionMetadata,
 	if taskExecutionMetadata.IsInterruptible() {
 		podSpec.NodeSelector = utils.UnionMaps(podSpec.NodeSelector, config.GetK8sPluginConfig().InterruptibleNodeSelector)
 	}
-	if podSpec.Affinity == nil {
-		podSpec.Affinity = config.GetK8sPluginConfig().DefaultAffinity
+	if podSpec.Affinity == nil && config.GetK8sPluginConfig().DefaultAffinity != nil {
+		podSpec.Affinity = config.GetK8sPluginConfig().DefaultAffinity.DeepCopy()
 	}
 	ApplyInterruptibleNodeAffinity(taskExecutionMetadata.IsInterruptible(), podSpec)
 }


### PR DESCRIPTION
Signed-off-by: Jeev B <jeev.balakrishnan@freenome.com>

# TL;DR
Fixes a case where `DefaultAffinity`, when set in k8s plugin config, will be clobbered during invocations of `UpdatePod` if `(Non)InterruptibleNodeSelectorRequirement` is also set.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
`.DeepCopy` `DefaultAffinity` to pod spec if it exists.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
