### PR TITLE
Fix default port for spark log links to match sandbox deployment

### DIFF
--- a/go/tasks/plugins/k8s/spark/config.go
+++ b/go/tasks/plugins/k8s/spark/config.go
@@ -12,7 +12,7 @@ var (
 		LogConfig: LogConfig{
 			Mixed: logs.LogConfig{
 				IsKubernetesEnabled:   true,
-				KubernetesTemplateURI: "http://localhost:30084/#!/log/{{ .namespace }}/{{ .podName }}/pod?namespace={{ .namespace }}",
+				KubernetesTemplateURI: "http://localhost:30082/#!/log/{{ .namespace }}/{{ .podName }}/pod?namespace={{ .namespace }}",
 			},
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Update spark's default config log link to match sandbox deployment.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/1378