### PR TITLE
Disable Interruptible for K8s array tasks

### DIFF
--- a/go/tasks/plugins/array/k8s/transformer.go
+++ b/go/tasks/plugins/array/k8s/transformer.go
@@ -141,7 +141,7 @@ func FlyteArrayJobToK8sPodTemplate(ctx context.Context, tCtx core.TaskExecutionC
 		},
 	}
 	if taskTemplate.GetContainer() != nil {
-		podSpec, err := flytek8s.ToK8sPodSpec(ctx, arrTCtx)
+		podSpec, err := flytek8s.ToK8sPodSpecWithInterruptible(ctx, arrTCtx, false)
 		if err != nil {
 			return v1.Pod{}, nil, err
 		}

--- a/go/tasks/plugins/array/k8s/transformer.go
+++ b/go/tasks/plugins/array/k8s/transformer.go
@@ -141,7 +141,7 @@ func FlyteArrayJobToK8sPodTemplate(ctx context.Context, tCtx core.TaskExecutionC
 		},
 	}
 	if taskTemplate.GetContainer() != nil {
-		podSpec, err := flytek8s.ToK8sPodSpecWithInterruptible(ctx, arrTCtx, false)
+		podSpec, err := flytek8s.ToK8sPodSpecWithInterruptible(ctx, arrTCtx, true)
 		if err != nil {
 			return v1.Pod{}, nil, err
 		}


### PR DESCRIPTION
K8s Array Interruptible is not implemented correctly unlike the regular k8s tasks. This results in failure for K8s tasks that are unaddressed. If spot instances are not available, we do not have provisions to remove the interruptible flag on retries so that they go to regular nodes.

https://github.com/flyteorg/flyte/issues/1533

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [S] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
