### PR TITLE
add support for batchScheduler in Spark Tasks

### DIFF
--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -210,6 +210,10 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 		},
 	}
 
+	if val, ok := sparkConfig["spark.batchScheduler"]; ok {
+		j.Spec.BatchScheduler = &val
+	}
+
 	if sparkJob.MainApplicationFile != "" {
 		j.Spec.MainApplicationFile = &sparkJob.MainApplicationFile
 	}


### PR DESCRIPTION
Signed-off-by: Miguel <mtoledo@lyft.com>

# TL;DR
Spark has support for batchScheduler such as Volcano however even if it enabled in the spark operator it cannot currently be used because we don't set it as part of the sparkApp.

Here we allow a user to specify `spark.batchScheduler` as part of their config to leverage the batchScheduler option. This can also be enabled for all spark tasks as part of the default spark config an admin sets in the plugins config

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
