### PR TITLE
Removed data config from copiliot pod spec

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/copilot_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/copilot_test.go
@@ -276,8 +276,6 @@ func assertPodHasCoPilot(t *testing.T, cfg config.FlyteCoPilotConfig, pilot *cor
 						}
 					}
 
-					_, ok := vmap[flyteDataConfigVolume]
-					assert.True(t, ok)
 				} else {
 					assert.Len(t, c.VolumeMounts, 0)
 				}

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -462,12 +462,6 @@ func TestToK8sPod(t *testing.T) {
 		})
 
 		assert.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{
-			DefaultTolerations: []v1.Toleration{
-				{
-					Key:   "tolerationKey",
-					Value: flyteDataConfigVolume,
-				},
-			},
 			DefaultNodeSelector: map[string]string{
 				"nodeId": "123",
 			},
@@ -478,7 +472,6 @@ func TestToK8sPod(t *testing.T) {
 
 		p, err := ToK8sPodSpec(ctx, x)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(p.Tolerations))
 		assert.Equal(t, 1, len(p.NodeSelector))
 		assert.Equal(t, "myScheduler", p.SchedulerName)
 		assert.Equal(t, "some-acceptable-name", p.Containers[0].Name)


### PR DESCRIPTION
# TL;DR
Now copilot shifted from config to command line flags. In Pr https://github.com/flyteorg/flyte/pull/1783 we removed the data config in helm chart but currently we didn't removed it from copilot package,

Removed data config volume from copilot pod spec, Now we don't need that volume, Propeller use it's own storage config for building the command for copilot pod spec.  


Testing:

![Screenshot 2021-11-17 at 3 46 30 PM](https://user-images.githubusercontent.com/10830562/142181929-606bdf18-dff9-4d72-84ef-14eba7c31a67.png)

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/1782

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
