### PR TITLE
Migrate ArrayJob to use TaskTemplate Config and deprecate ArrayJob proto 

### DIFF
--- a/go/tasks/plugins/array/array_tests_base.go
+++ b/go/tasks/plugins/array/array_tests_base.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/flyteorg/flyteplugins/tests"
+	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
 
 	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flytestdlib/utils"
@@ -47,7 +48,7 @@ func RunArrayTestsEndToEnd(t *testing.T, executor core.Plugin, iter AdvanceItera
 		}
 
 		var err error
-		template.Custom, err = utils.MarshalObjToStruct(&ArrayJob{
+		template.Custom, err = utils.MarshalObjToStruct(&arrayCore.ArrayJob{
 			Parallelism:  10,
 			Size:         1,
 			MinSuccesses: 1,
@@ -80,7 +81,7 @@ func RunArrayTestsEndToEnd(t *testing.T, executor core.Plugin, iter AdvanceItera
 		}
 
 		var err error
-		template.Custom, err = utils.MarshalObjToStruct(&ArrayJob{
+		template.Custom, err = utils.MarshalObjToStruct(&arrayCore.ArrayJob{
 			Parallelism:  10,
 			Size:         2,
 			MinSuccesses: 1,

--- a/go/tasks/plugins/array/array_tests_base.go
+++ b/go/tasks/plugins/array/array_tests_base.go
@@ -3,8 +3,8 @@ package array
 import (
 	"testing"
 
-	"github.com/flyteorg/flyteplugins/tests"
 	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
+	"github.com/flyteorg/flyteplugins/tests"
 
 	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flytestdlib/utils"

--- a/go/tasks/plugins/array/array_tests_base.go
+++ b/go/tasks/plugins/array/array_tests_base.go
@@ -6,8 +6,6 @@ import (
 	"github.com/flyteorg/flyteplugins/tests"
 
 	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-
-	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
 	"github.com/flyteorg/flytestdlib/utils"
 
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
@@ -49,12 +47,10 @@ func RunArrayTestsEndToEnd(t *testing.T, executor core.Plugin, iter AdvanceItera
 		}
 
 		var err error
-		template.Custom, err = utils.MarshalPbToStruct(&plugins.ArrayJob{
-			Parallelism: 10,
-			Size:        1,
-			SuccessCriteria: &plugins.ArrayJob_MinSuccesses{
-				MinSuccesses: 1,
-			},
+		template.Custom, err = utils.MarshalObjToStruct(&ArrayJob{
+			Parallelism:  10,
+			Size:         1,
+			MinSuccesses: 1,
 		})
 
 		assert.NoError(t, err)
@@ -84,12 +80,10 @@ func RunArrayTestsEndToEnd(t *testing.T, executor core.Plugin, iter AdvanceItera
 		}
 
 		var err error
-		template.Custom, err = utils.MarshalPbToStruct(&plugins.ArrayJob{
-			Parallelism: 10,
-			Size:        2,
-			SuccessCriteria: &plugins.ArrayJob_MinSuccesses{
-				MinSuccesses: 1,
-			},
+		template.Custom, err = utils.MarshalObjToStruct(&ArrayJob{
+			Parallelism:  10,
+			Size:         2,
+			MinSuccesses: 1,
 		})
 
 		assert.NoError(t, err)

--- a/go/tasks/plugins/array/awsbatch/transformer_test.go
+++ b/go/tasks/plugins/array/awsbatch/transformer_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
+	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -136,7 +136,7 @@ func TestArrayJobToBatchInput(t *testing.T) {
 		},
 	}
 
-	input := &plugins.ArrayJob{
+	input := &array.ArrayJob{
 		Size:        10,
 		Parallelism: 5,
 	}

--- a/go/tasks/plugins/array/awsbatch/transformer_test.go
+++ b/go/tasks/plugins/array/awsbatch/transformer_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/batch"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array"
+	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -136,7 +136,7 @@ func TestArrayJobToBatchInput(t *testing.T) {
 		},
 	}
 
-	input := &array.ArrayJob{
+	input := &arrayCore.ArrayJob{
 		Size:        10,
 		Parallelism: 5,
 	}

--- a/go/tasks/plugins/array/catalog.go
+++ b/go/tasks/plugins/array/catalog.go
@@ -50,7 +50,7 @@ func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContex
 	if taskTemplate.TaskTypeVersion == 0 {
 		state = state.SetOriginalArraySize(arrayJob.Size)
 		arrayJobSize = arrayJob.Size
-		state = state.SetOriginalMinSuccesses(arrayJob.MinSuccesses)
+		state = state.SetOriginalMinSuccesses(arrayJob.GetMinSuccesses())
 
 		// build input readers
 		inputReaders, err = ConstructRemoteFileInputReaders(ctx, tCtx.DataStore(), tCtx.InputReader().GetInputPrefixPath(), int(arrayJobSize))
@@ -81,7 +81,7 @@ func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContex
 			return state, errors.Errorf(errors.BadTaskSpecification, "Unable to determine array size from inputs")
 		}
 
-		minSuccesses := math.Ceil(float64(arrayJob.MinSuccesses) * float64(size))
+		minSuccesses := math.Ceil(float64(arrayJob.GetMinSuccesses()) * float64(size))
 
 		logger.Debugf(ctx, "Computed state: size [%d] and minSuccesses [%d]", int64(size), int64(minSuccesses))
 		state = state.SetOriginalArraySize(int64(size))

--- a/go/tasks/plugins/array/catalog.go
+++ b/go/tasks/plugins/array/catalog.go
@@ -21,13 +21,6 @@ import (
 	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 )
 
-type ArrayJob struct {
-	Parallelism     int64
-	Size            int64
-	MinSuccesses    int64
-	MinSuccessRatio float64
-}
-
 // DetermineDiscoverability checks if there are any previously cached tasks. If there are we will only submit an
 // ArrayJob for the non-cached tasks. The ArrayJob is now a different size, and each task will get a new index location
 // which is different than their original location. To find the original index we construct an indexLookup array.
@@ -45,7 +38,7 @@ func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContex
 	}
 
 	// Extract the custom plugin pb
-	arrayJob, err := arrayCore.ToArrayJob(taskTemplate.Config, taskTemplate.TaskTypeVersion)
+	arrayJob, err := arrayCore.ToArrayJob(taskTemplate.GetConfig(), taskTemplate.TaskTypeVersion)
 	if err != nil {
 		return state, err
 	}

--- a/go/tasks/plugins/array/catalog_test.go
+++ b/go/tasks/plugins/array/catalog_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 
@@ -244,13 +243,11 @@ func TestDiscoverabilityTaskType1(t *testing.T) {
 		download.OnGetCachedResults().Return(bitarray.NewBitSet(1)).Once()
 		toCache := arrayCore.InvertBitSet(bitarray.NewBitSet(uint(3)), uint(3))
 
-		arrayJob := &plugins.ArrayJob{
-			SuccessCriteria: &plugins.ArrayJob_MinSuccessRatio{
-				MinSuccessRatio: 0.5,
-			},
+		arrayJob := &ArrayJob{
+			MinSuccessRatio: 0.5,
 		}
-		var arrayJobCustom structpb.Struct
-		err := utils.MarshalStruct(arrayJob, &arrayJobCustom)
+		var arrayJobCustom *structpb.Struct
+		arrayJobCustom, err := utils.MarshalObjToStruct(arrayJob)
 		assert.NoError(t, err)
 		templateType1 := &core.TaskTemplate{
 			Id: &core.Identifier{
@@ -276,7 +273,7 @@ func TestDiscoverabilityTaskType1(t *testing.T) {
 				},
 			},
 			TaskTypeVersion: 1,
-			Custom:          &arrayJobCustom,
+			Custom:          arrayJobCustom,
 		}
 
 		runDetermineDiscoverabilityTest(t, templateType1, f, &arrayCore.State{

--- a/go/tasks/plugins/array/catalog_test.go
+++ b/go/tasks/plugins/array/catalog_test.go
@@ -243,7 +243,7 @@ func TestDiscoverabilityTaskType1(t *testing.T) {
 		download.OnGetCachedResults().Return(bitarray.NewBitSet(1)).Once()
 		toCache := arrayCore.InvertBitSet(bitarray.NewBitSet(uint(3)), uint(3))
 
-		arrayJob := &ArrayJob{
+		arrayJob := &arrayCore.ArrayJob{
 			MinSuccessRatio: 0.5,
 		}
 		var arrayJobCustom *structpb.Struct

--- a/go/tasks/plugins/array/core/array_job.go
+++ b/go/tasks/plugins/array/core/array_job.go
@@ -1,0 +1,26 @@
+package core
+
+
+type ArrayJob struct {
+	Parallelism     int64
+	Size            int64
+	MinSuccesses    int64
+	MinSuccessRatio float64
+}
+
+func (a ArrayJob) GetParallelism() int64 {
+	return a.Parallelism
+}
+
+func (a ArrayJob) GetSize() int64 {
+	return a.Size
+}
+
+func (a ArrayJob) GetMinSuccesses() int64 {
+	return a.MinSuccesses
+}
+
+func (a ArrayJob) GetMinSuccessRatio() float64 {
+	return a.MinSuccessRatio
+}
+

--- a/go/tasks/plugins/array/core/array_job.go
+++ b/go/tasks/plugins/array/core/array_job.go
@@ -1,6 +1,5 @@
 package core
 
-
 type ArrayJob struct {
 	Parallelism     int64
 	Size            int64
@@ -23,4 +22,3 @@ func (a ArrayJob) GetMinSuccesses() int64 {
 func (a ArrayJob) GetMinSuccessRatio() float64 {
 	return a.MinSuccessRatio
 }
-

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -15,7 +15,6 @@ import (
 
 	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
-	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array"
 	"github.com/flyteorg/flytestdlib/logger"
 )
 
@@ -132,32 +131,32 @@ const (
 	ErrorK8sArrayGeneric  errors.ErrorCode = "ARRAY_JOB_GENERIC_FAILURE"
 )
 
-func ToArrayJob(config map[string]string, taskTypeVersion int32) (*array.ArrayJob, error) {
+func ToArrayJob(config map[string]string, taskTypeVersion int32) (*ArrayJob, error) {
 	if config == nil {
 		if taskTypeVersion == 0 {
-			return &array.ArrayJob{
+			return &ArrayJob{
 				Parallelism:  1,
 				Size:         1,
 				MinSuccesses: 1,
 			}, nil
 		}
-		return &array.ArrayJob{
+		return &ArrayJob{
 			Parallelism:     1,
 			Size:            1,
 			MinSuccessRatio: 1.0,
 		}, nil
 	}
 
-	arrayJob := &array.ArrayJob{}
+	arrayJob := &ArrayJob{}
 	var err error
 	if config["Parallelism"] != "" {
-		arrayJob.Parallelism, err = strconv.Atoi(config["Parallelism"])
+		arrayJob.Parallelism, err = strconv.ParseInt(config["Parallelism"], 10,64)
 	}
 	if config["Size"] != "" {
-		arrayJob.Size, err = strconv.Atoi(config["Size"])
+		arrayJob.Size, err = strconv.ParseInt(config["Size"], 10, 64)
 	}
 	if config["MinSuccesses"] != "" {
-		arrayJob.MinSuccesses, err = strconv.Atoi(config["MinSuccesses"])
+		arrayJob.MinSuccesses, err = strconv.ParseInt(config["MinSuccesses"], 10, 64)
 	}
 	if config["MinSuccessRatio"] != "" {
 		arrayJob.MinSuccessRatio, err = strconv.ParseFloat(config["MinSuccessRatio"], 64)

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -150,7 +150,7 @@ func ToArrayJob(config map[string]string, taskTypeVersion int32) (*ArrayJob, err
 	arrayJob := &ArrayJob{}
 	var err error
 	if config["Parallelism"] != "" {
-		arrayJob.Parallelism, err = strconv.ParseInt(config["Parallelism"], 10,64)
+		arrayJob.Parallelism, err = strconv.ParseInt(config["Parallelism"], 10, 64)
 	}
 	if config["Size"] != "" {
 		arrayJob.Size, err = strconv.ParseInt(config["Size"], 10, 64)

--- a/go/tasks/plugins/array/core/state_test.go
+++ b/go/tasks/plugins/array/core/state_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/event"
 
-	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
+	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array"
 	"github.com/golang/protobuf/proto"
 
 	"github.com/flyteorg/flytestdlib/bitarray"
@@ -247,24 +247,20 @@ func TestToArrayJob(t *testing.T) {
 	t.Run("task_type_version == 0", func(t *testing.T) {
 		arrayJob, err := ToArrayJob(nil, 0)
 		assert.NoError(t, err)
-		assert.True(t, proto.Equal(arrayJob, &plugins.ArrayJob{
-			Parallelism: 1,
-			Size:        1,
-			SuccessCriteria: &plugins.ArrayJob_MinSuccesses{
-				MinSuccesses: 1,
-			},
-		}))
+		assert.True(t, *arrayJob == array.ArrayJob{
+			Parallelism:  1,
+			Size:         1,
+			MinSuccesses: 1,
+		})
 	})
 
 	t.Run("task_type_version == 1", func(t *testing.T) {
 		arrayJob, err := ToArrayJob(nil, 1)
 		assert.NoError(t, err)
-		assert.True(t, proto.Equal(arrayJob, &plugins.ArrayJob{
-			Parallelism: 1,
-			Size:        1,
-			SuccessCriteria: &plugins.ArrayJob_MinSuccessRatio{
-				MinSuccessRatio: 1.0,
-			},
-		}))
+		assert.True(t, *arrayJob == array.ArrayJob{
+			Parallelism:     1,
+			Size:            1,
+			MinSuccessRatio: 1.0,
+		})
 	})
 }

--- a/go/tasks/plugins/array/core/state_test.go
+++ b/go/tasks/plugins/array/core/state_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/event"
 
-	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array"
 	"github.com/golang/protobuf/proto"
 
 	"github.com/flyteorg/flytestdlib/bitarray"
@@ -247,7 +246,7 @@ func TestToArrayJob(t *testing.T) {
 	t.Run("task_type_version == 0", func(t *testing.T) {
 		arrayJob, err := ToArrayJob(nil, 0)
 		assert.NoError(t, err)
-		assert.True(t, *arrayJob == array.ArrayJob{
+		assert.True(t, *arrayJob == ArrayJob{
 			Parallelism:  1,
 			Size:         1,
 			MinSuccesses: 1,
@@ -257,7 +256,7 @@ func TestToArrayJob(t *testing.T) {
 	t.Run("task_type_version == 1", func(t *testing.T) {
 		arrayJob, err := ToArrayJob(nil, 1)
 		assert.NoError(t, err)
-		assert.True(t, *arrayJob == array.ArrayJob{
+		assert.True(t, *arrayJob == ArrayJob{
 			Parallelism:     1,
 			Size:            1,
 			MinSuccessRatio: 1.0,

--- a/go/tasks/plugins/array/k8s/transformer.go
+++ b/go/tasks/plugins/array/k8s/transformer.go
@@ -14,7 +14,7 @@ import (
 	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array"
 
 	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-	idlPlugins "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
+	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/errors"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s"
@@ -97,7 +97,7 @@ func buildPodMapTask(task *idlCore.TaskTemplate, metadata core.TaskExecutionMeta
 // FlyteArrayJobToK8sPodTemplate returns a pod template for the given task context. Note that Name is not set on the
 // result object. It's up to the caller to set the Name before creating the object in K8s.
 func FlyteArrayJobToK8sPodTemplate(ctx context.Context, tCtx core.TaskExecutionContext, namespaceTemplate string) (
-	podTemplate v1.Pod, job *idlPlugins.ArrayJob, err error) {
+	podTemplate v1.Pod, job *arrayCore.ArrayJob, err error) {
 
 	// Check that the taskTemplate is valid
 	taskTemplate, err := tCtx.TaskReader().Read(ctx)
@@ -117,9 +117,9 @@ func FlyteArrayJobToK8sPodTemplate(ctx context.Context, tCtx core.TaskExecutionC
 		arrayInputReader:     array.GetInputReader(tCtx, taskTemplate),
 	}
 
-	var arrayJob *idlPlugins.ArrayJob
+	var arrayJob *arrayCore.ArrayJob
 	if taskTemplate.GetCustom() != nil {
-		arrayJob, err = core2.ToArrayJob(taskTemplate.GetCustom(), taskTemplate.TaskTypeVersion)
+		arrayJob, err = core2.ToArrayJob(taskTemplate.GetConfig(), taskTemplate.TaskTypeVersion)
 		if err != nil {
 			return v1.Pod{}, nil, err
 		}

--- a/go/tasks/plugins/array/k8s/transformer.go
+++ b/go/tasks/plugins/array/k8s/transformer.go
@@ -14,10 +14,10 @@ import (
 	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array"
 
 	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/errors"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s"
+	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
 	core2 "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/go/tasks/plugins/array/k8s/transformer_test.go
+++ b/go/tasks/plugins/array/k8s/transformer_test.go
@@ -11,10 +11,10 @@ import (
 	"github.com/flyteorg/flytestdlib/storage"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
-	idlPlugins "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 	mocks2 "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io/mocks"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
+	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -42,7 +42,7 @@ var podSpec = v1.PodSpec{
 	},
 }
 
-var arrayJob = idlPlugins.ArrayJob{
+var arrayJob = array.ArrayJob{
 	Size: 100,
 }
 
@@ -57,8 +57,8 @@ func getK8sPodTask(t *testing.T, annotations map[string]string) *core.TaskTempla
 		t.Fatal(err)
 	}
 
-	custom := &structpb.Struct{}
-	if err := utils.MarshalStruct(&arrayJob, custom); err != nil {
+	var custom *structpb.Struct
+	if custom, err = utils.MarshalObjToStruct(&arrayJob); err != nil {
 		t.Fatal(err)
 	}
 

--- a/go/tasks/plugins/array/k8s/transformer_test.go
+++ b/go/tasks/plugins/array/k8s/transformer_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 	mocks2 "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io/mocks"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
-	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array"
+	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -42,7 +42,7 @@ var podSpec = v1.PodSpec{
 	},
 }
 
-var arrayJob = array.ArrayJob{
+var arrayJob = arrayCore.ArrayJob{
 	Size: 100,
 }
 


### PR DESCRIPTION
# TL;DR
Migrate ArrayJob to use TaskTemplate Config and deprecate ArrayJob proto 
https://github.com/flyteorg/flyte/issues/1791

## Type
 - [ ] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
