### PR TITLE
BigQuery plugin failed to read credential

### DIFF
--- a/go/tasks/plugins/webapi/bigquery/integration_test.go
+++ b/go/tasks/plugins/webapi/bigquery/integration_test.go
@@ -47,7 +47,6 @@ func TestEndToEnd(t *testing.T) {
 	t.Run("SELECT 1", func(t *testing.T) {
 		queryJobConfig := QueryJobConfig{
 			ProjectID: "flyte",
-			Query:     "SELECT 1",
 		}
 
 		inputs, _ := coreutils.MakeLiteralMap(map[string]interface{}{"x": 1})
@@ -55,6 +54,7 @@ func TestEndToEnd(t *testing.T) {
 		template := flyteIdlCore.TaskTemplate{
 			Type:   bigqueryQueryJobTask,
 			Custom: custom,
+			Target: &flyteIdlCore.TaskTemplate_Sql{Sql: &flyteIdlCore.Sql{Statement: "SELECT 1", Dialect: flyteIdlCore.Sql_ANSI}},
 		}
 
 		phase := tests.RunPluginEndToEndTest(t, plugin, &template, inputs, nil, nil, iter)

--- a/go/tasks/plugins/webapi/bigquery/plugin.go
+++ b/go/tasks/plugins/webapi/bigquery/plugin.go
@@ -457,6 +457,14 @@ func (p Plugin) newBigQueryClient(ctx context.Context, identity google.Identity)
 		options = append(options,
 			option.WithEndpoint(p.cfg.bigQueryEndpoint),
 			option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{})))
+	} else if p.cfg.GoogleTokenSource.Type != "default" {
+		tokenSource, err := p.googleTokenSource.GetTokenSource(ctx, identity)
+
+		if err != nil {
+			return nil, pluginErrors.Wrapf(pluginErrors.RuntimeFailure, err, "unable to get token source")
+		}
+
+		options = append(options, option.WithTokenSource(tokenSource))
 	}
 
 	return bigquery.NewService(ctx, options...)

--- a/go/tasks/plugins/webapi/bigquery/plugin.go
+++ b/go/tasks/plugins/webapi/bigquery/plugin.go
@@ -458,6 +458,7 @@ func (p Plugin) newBigQueryClient(ctx context.Context, identity google.Identity)
 			option.WithEndpoint(p.cfg.bigQueryEndpoint),
 			option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{})))
 	} else if p.cfg.GoogleTokenSource.Type != "default" {
+
 		tokenSource, err := p.googleTokenSource.GetTokenSource(ctx, identity)
 
 		if err != nil {
@@ -465,6 +466,8 @@ func (p Plugin) newBigQueryClient(ctx context.Context, identity google.Identity)
 		}
 
 		options = append(options, option.WithTokenSource(tokenSource))
+	} else {
+		logger.Infof(ctx, "BigQuery client read $GOOGLE_APPLICATION_CREDENTIALS by default")
 	}
 
 	return bigquery.NewService(ctx, options...)

--- a/go/tasks/plugins/webapi/bigquery/plugin.go
+++ b/go/tasks/plugins/webapi/bigquery/plugin.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"time"
 
+	"golang.org/x/oauth2"
+
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/google"
@@ -448,6 +450,13 @@ func (p Plugin) newBigQueryClient(ctx context.Context, identity google.Identity)
 		option.WithScopes("https://www.googleapis.com/auth/bigquery"),
 		// FIXME how do I access current version?
 		option.WithUserAgent(fmt.Sprintf("%s/%s", "flytepropeller", "LATEST")),
+	}
+
+	// for mocking/testing purposes
+	if p.cfg.bigQueryEndpoint != "" {
+		options = append(options,
+			option.WithEndpoint(p.cfg.bigQueryEndpoint),
+			option.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{})))
 	}
 
 	return bigquery.NewService(ctx, options...)

--- a/go/tasks/plugins/webapi/bigquery/query_job.go
+++ b/go/tasks/plugins/webapi/bigquery/query_job.go
@@ -161,6 +161,9 @@ func getJobConfigurationQuery(custom *QueryJobConfig, inputs *flyteIdlCore.Liter
 		return nil, pluginErrors.Errorf(pluginErrors.BadTaskSpecification, "unable build query parameters [%v]", err.Error())
 	}
 
+	// BigQuery supports query parameters to help prevent SQL injection when queries are constructed using user input.
+	// This feature is only available with standard SQL syntax. For more detail: https://cloud.google.com/bigquery/docs/parameterized-queries
+	useLegacySQL := false
 	return &bigquery.JobConfigurationQuery{
 		AllowLargeResults:                  custom.AllowLargeResults,
 		Clustering:                         custom.Clustering,
@@ -178,7 +181,7 @@ func getJobConfigurationQuery(custom *QueryJobConfig, inputs *flyteIdlCore.Liter
 		SchemaUpdateOptions:                custom.SchemaUpdateOptions,
 		TableDefinitions:                   custom.TableDefinitions,
 		TimePartitioning:                   custom.TimePartitioning,
-		UseLegacySql:                       custom.UseLegacySQL,
+		UseLegacySql:                       &useLegacySQL,
 		UseQueryCache:                      custom.UseQueryCache,
 		UserDefinedFunctionResources:       custom.UserDefinedFunctionResources,
 		WriteDisposition:                   custom.WriteDisposition,

--- a/go/tasks/plugins/webapi/bigquery/query_job_test.go
+++ b/go/tasks/plugins/webapi/bigquery/query_job_test.go
@@ -69,10 +69,11 @@ func TestGetJobConfigurationQuery(t *testing.T) {
 		})
 
 		jobConfigurationQuery, err := getJobConfigurationQuery(&config, inputs)
+		useLegacySQL := false
 
 		assert.NoError(t, err)
 		assert.Equal(t, "NAMED", jobConfigurationQuery.ParameterMode)
-
+		assert.Equal(t, &useLegacySQL, jobConfigurationQuery.UseLegacySql)
 		assert.Equal(t, 1, len(jobConfigurationQuery.QueryParameters))
 		assert.Equal(t, bigquery.QueryParameter{
 			Name:           "integer",


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Before:
1. Failed to use parameter in SQL statement
2. BQ client failed to read credentials

![image](https://user-images.githubusercontent.com/37936015/147557032-389a9032-5125-40dc-a57a-5531c21afbc9.png)

![image](https://user-images.githubusercontent.com/37936015/147557113-eca39632-ef86-4276-9e06-82787fd26c04.png)

After:
Check flytesnack example: https://github.com/flyteorg/flytesnacks/pull/521

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
1. UseLegacySql should always be false
2. We don't need to pass a token source to the BQ client when using the default token source factory. 

`GetTokenSource` will try to create credentials by reading `$GOOGLE_APPLICATION_CREDENTIALS`, but by default the BQ client will read `$GOOGLE_APPLICATION_CREDENTIALS` when it creates a connection. Therefore, we don't need to create credentials by ourselves.
https://github.com/flyteorg/flyteplugins/blob/fea5d848a5fe20b30d3a1d24c9e18f3706a6b7c4/go/tasks/pluginmachinery/google/default_token_source_factory.go#L12-L14


## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_