### PR TITLE
Retry map task subtasks

### DIFF
--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -121,7 +121,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		nextState, err = array.WriteToDiscovery(ctx, tCtx, pluginState, arrayCore.PhaseAssembleFinalOutput)
 
 	case arrayCore.PhaseAssembleFinalError:
-		nextState, err = array.AssembleFinalOutputs(ctx, e.errorAssembler, tCtx, arrayCore.PhaseRetryableFailure, pluginState)
+		nextState, err = array.AssembleFinalOutputs(ctx, e.errorAssembler, tCtx, arrayCore.PhasePermanentFailure, pluginState)
 
 	default:
 		nextState = pluginState

--- a/go/tasks/plugins/array/k8s/launcher.go
+++ b/go/tasks/plugins/array/k8s/launcher.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
 
@@ -33,7 +34,16 @@ var arrayJobEnvVars = []corev1.EnvVar{
 	},
 }
 
-func formatSubTaskName(_ context.Context, parentName, indexStr, retryAttemptStr string) (subTaskName string) {
+func formatSubTaskName(_ context.Context, parentName string, index int, retryAttempt uint64) (subTaskName string) {
+	indexStr := strconv.Itoa(index)
+
+	// If the retryAttempt is 0 we do not include it in the pod name. The gives us backwards
+	// compatibility in the ability to dynamically transition running map tasks to use subtask retries.
+	if retryAttempt == 0 {
+		return utils.ConvertToDNS1123SubdomainCompatibleString(fmt.Sprintf("%v-%v", parentName, indexStr))
+	}
+
+	retryAttemptStr := strconv.FormatUint(retryAttempt, 10)
 	return utils.ConvertToDNS1123SubdomainCompatibleString(fmt.Sprintf("%v-%v-%v", parentName, indexStr, retryAttemptStr))
 }
 

--- a/go/tasks/plugins/array/k8s/launcher.go
+++ b/go/tasks/plugins/array/k8s/launcher.go
@@ -33,8 +33,8 @@ var arrayJobEnvVars = []corev1.EnvVar{
 	},
 }
 
-func formatSubTaskName(_ context.Context, parentName, suffix string) (subTaskName string) {
-	return utils.ConvertToDNS1123SubdomainCompatibleString(fmt.Sprintf("%v-%v", parentName, suffix))
+func formatSubTaskName(_ context.Context, parentName, indexStr, retryAttemptStr string) (subTaskName string) {
+	return utils.ConvertToDNS1123SubdomainCompatibleString(fmt.Sprintf("%v-%v-%v", parentName, indexStr, retryAttemptStr))
 }
 
 func ApplyPodPolicies(_ context.Context, cfg *Config, pod *corev1.Pod) *corev1.Pod {

--- a/go/tasks/plugins/array/k8s/launcher_test.go
+++ b/go/tasks/plugins/array/k8s/launcher_test.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	"fmt"
 	"context"
 	"testing"
 
@@ -38,4 +39,26 @@ func TestApplyPodTolerations(t *testing.T) {
 	pod = applyPodTolerations(ctx, cfg, pod)
 
 	assert.Equal(t, pod.Spec.Tolerations, cfg.Tolerations)
+}
+
+func TestFormatSubTaskName(t *testing.T) {
+	ctx := context.Background()
+	parentName := "foo"
+
+	tests := []struct {
+		index        int
+		retryAttempt uint64
+		want         string
+	}{
+		{0, 0, fmt.Sprintf("%v-%v", parentName, 0)},
+		{1, 0, fmt.Sprintf("%v-%v", parentName, 1)},
+		{0, 1, fmt.Sprintf("%v-%v-%v", parentName, 0, 1)},
+		{1, 1, fmt.Sprintf("%v-%v-%v", parentName, 1, 1)},
+	}
+
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("format-subtask-name-%v", i), func(t *testing.T) {
+			assert.Equal(t, tt.want, formatSubTaskName(ctx, parentName, tt.index, tt.retryAttempt))
+		})
+	}
 }

--- a/go/tasks/plugins/array/k8s/launcher_test.go
+++ b/go/tasks/plugins/array/k8s/launcher_test.go
@@ -1,8 +1,8 @@
 package k8s
 
 import (
-	"fmt"
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/go/tasks/plugins/array/k8s/monitor.go
+++ b/go/tasks/plugins/array/k8s/monitor.go
@@ -72,8 +72,11 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 			return currentState, logLinks, subTaskIDs, nil
 		}
 
+		// Set subtask retryAttempts using the existing task context retry attempt. For new tasks
+		// this will initialize to 0, but running tasks will use the existing retry attempt.
+		retryAttempt := bitarray.Item(tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetID().RetryAttempt)
 		for i := 0; i < currentState.GetExecutionArraySize(); i++ {
-			retryAttemptsArray.SetItem(i, 0)
+			retryAttemptsArray.SetItem(i, retryAttempt)
 		}
 
 		currentState.RetryAttempts = retryAttemptsArray

--- a/go/tasks/plugins/array/k8s/monitor.go
+++ b/go/tasks/plugins/array/k8s/monitor.go
@@ -111,7 +111,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 			// so that is not attempted again. If it can be retried, increment the retry attempts
 			// value and transition the task to "Undefined" so that it is reevaluated.
 			if existingPhase == core.PhaseRetryableFailure {
-				if uint32(retryAttempt) < tCtx.TaskExecutionMetadata().GetMaxAttempts() {
+				if uint32(retryAttempt + 1) < tCtx.TaskExecutionMetadata().GetMaxAttempts() {
 					newState.RetryAttempts.SetItem(childIdx, retryAttempt+1)
 
 					newArrayStatus.Summary.Inc(core.PhaseUndefined)

--- a/go/tasks/plugins/array/k8s/monitor.go
+++ b/go/tasks/plugins/array/k8s/monitor.go
@@ -111,7 +111,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 			// so that is not attempted again. If it can be retried, increment the retry attempts
 			// value and transition the task to "Undefined" so that it is reevaluated.
 			if existingPhase == core.PhaseRetryableFailure {
-				if uint32(retryAttempt + 1) < tCtx.TaskExecutionMetadata().GetMaxAttempts() {
+				if uint32(retryAttempt+1) < tCtx.TaskExecutionMetadata().GetMaxAttempts() {
 					newState.RetryAttempts.SetItem(childIdx, retryAttempt+1)
 
 					newArrayStatus.Summary.Inc(core.PhaseUndefined)

--- a/go/tasks/plugins/array/k8s/monitor.go
+++ b/go/tasks/plugins/array/k8s/monitor.go
@@ -112,7 +112,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 			if existingPhase == core.PhaseRetryableFailure {
 				retryAttempt := currentState.RetryAttempts.GetItem(childIdx)
 				if uint32(retryAttempt) < tCtx.TaskExecutionMetadata().GetMaxAttempts() {
-					newState.RetryAttempts.SetItem(childIdx, retryAttempt + 1)
+					newState.RetryAttempts.SetItem(childIdx, retryAttempt+1)
 
 					newArrayStatus.Summary.Inc(core.PhaseUndefined)
 					newArrayStatus.Detailed.SetItem(childIdx, bitarray.Item(core.PhaseUndefined))

--- a/go/tasks/plugins/array/k8s/monitor_test.go
+++ b/go/tasks/plugins/array/k8s/monitor_test.go
@@ -173,10 +173,10 @@ func TestCheckSubTasksState(t *testing.T) {
 		assert.NotEmpty(t, logLinks)
 		assert.Equal(t, 10, len(logLinks))
 		for i := 0; i < 10; i = i + 2 {
-			assert.Equal(t, fmt.Sprintf("Kubernetes Logs #0-%d (PhaseRunning)", i/2), logLinks[i].Name)
+			assert.Equal(t, fmt.Sprintf("Kubernetes Logs #0-%d-0 (PhaseRunning)", i/2), logLinks[i].Name)
 			assert.Equal(t, fmt.Sprintf("k8s/log/a-n-b/notfound-%d-0/pod?namespace=a-n-b", i/2), logLinks[i].Uri)
 
-			assert.Equal(t, fmt.Sprintf("Cloudwatch Logs #0-%d (PhaseRunning)", i/2), logLinks[i+1].Name)
+			assert.Equal(t, fmt.Sprintf("Cloudwatch Logs #0-%d-0 (PhaseRunning)", i/2), logLinks[i+1].Name)
 			assert.Equal(t, fmt.Sprintf("https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=/kubernetes/flyte;prefix=var.log.containers.notfound-%d-0;streamFilter=typeLogStreamPrefix", i/2), logLinks[i+1].Uri)
 		}
 

--- a/go/tasks/plugins/array/k8s/monitor_test.go
+++ b/go/tasks/plugins/array/k8s/monitor_test.go
@@ -113,7 +113,7 @@ func TestGetNamespaceForExecution(t *testing.T) {
 func testSubTaskIDs(t *testing.T, actual []*string) {
 	var expected = make([]*string, 5)
 	for i := 0; i < len(expected); i++ {
-		subTaskID := fmt.Sprintf("notfound-%d", i)
+		subTaskID := fmt.Sprintf("notfound-%d-0", i)
 		expected[i] = &subTaskID
 	}
 	assert.EqualValues(t, expected, actual)
@@ -174,10 +174,10 @@ func TestCheckSubTasksState(t *testing.T) {
 		assert.Equal(t, 10, len(logLinks))
 		for i := 0; i < 10; i = i + 2 {
 			assert.Equal(t, fmt.Sprintf("Kubernetes Logs #0-%d (PhaseRunning)", i/2), logLinks[i].Name)
-			assert.Equal(t, fmt.Sprintf("k8s/log/a-n-b/notfound-%d/pod?namespace=a-n-b", i/2), logLinks[i].Uri)
+			assert.Equal(t, fmt.Sprintf("k8s/log/a-n-b/notfound-%d-0/pod?namespace=a-n-b", i/2), logLinks[i].Uri)
 
 			assert.Equal(t, fmt.Sprintf("Cloudwatch Logs #0-%d (PhaseRunning)", i/2), logLinks[i+1].Name)
-			assert.Equal(t, fmt.Sprintf("https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=/kubernetes/flyte;prefix=var.log.containers.notfound-%d;streamFilter=typeLogStreamPrefix", i/2), logLinks[i+1].Uri)
+			assert.Equal(t, fmt.Sprintf("https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=/kubernetes/flyte;prefix=var.log.containers.notfound-%d-0;streamFilter=typeLogStreamPrefix", i/2), logLinks[i+1].Uri)
 		}
 
 		p, _ := newState.GetPhase()

--- a/go/tasks/plugins/array/k8s/monitor_test.go
+++ b/go/tasks/plugins/array/k8s/monitor_test.go
@@ -113,7 +113,7 @@ func TestGetNamespaceForExecution(t *testing.T) {
 func testSubTaskIDs(t *testing.T, actual []*string) {
 	var expected = make([]*string, 5)
 	for i := 0; i < len(expected); i++ {
-		subTaskID := fmt.Sprintf("notfound-%d-0", i)
+		subTaskID := fmt.Sprintf("notfound-%d", i)
 		expected[i] = &subTaskID
 	}
 	assert.EqualValues(t, expected, actual)
@@ -173,11 +173,11 @@ func TestCheckSubTasksState(t *testing.T) {
 		assert.NotEmpty(t, logLinks)
 		assert.Equal(t, 10, len(logLinks))
 		for i := 0; i < 10; i = i + 2 {
-			assert.Equal(t, fmt.Sprintf("Kubernetes Logs #0-%d-0 (PhaseRunning)", i/2), logLinks[i].Name)
-			assert.Equal(t, fmt.Sprintf("k8s/log/a-n-b/notfound-%d-0/pod?namespace=a-n-b", i/2), logLinks[i].Uri)
+			assert.Equal(t, fmt.Sprintf("Kubernetes Logs #0-%d (PhaseRunning)", i/2), logLinks[i].Name)
+			assert.Equal(t, fmt.Sprintf("k8s/log/a-n-b/notfound-%d/pod?namespace=a-n-b", i/2), logLinks[i].Uri)
 
-			assert.Equal(t, fmt.Sprintf("Cloudwatch Logs #0-%d-0 (PhaseRunning)", i/2), logLinks[i+1].Name)
-			assert.Equal(t, fmt.Sprintf("https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=/kubernetes/flyte;prefix=var.log.containers.notfound-%d-0;streamFilter=typeLogStreamPrefix", i/2), logLinks[i+1].Uri)
+			assert.Equal(t, fmt.Sprintf("Cloudwatch Logs #0-%d (PhaseRunning)", i/2), logLinks[i+1].Name)
+			assert.Equal(t, fmt.Sprintf("https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=/kubernetes/flyte;prefix=var.log.containers.notfound-%d;streamFilter=typeLogStreamPrefix", i/2), logLinks[i+1].Uri)
 		}
 
 		p, _ := newState.GetPhase()

--- a/go/tasks/plugins/array/k8s/task.go
+++ b/go/tasks/plugins/array/k8s/task.go
@@ -114,9 +114,7 @@ func (t Task) Launch(ctx context.Context, tCtx core.TaskExecutionContext, kubeCl
 		return LaunchError, err
 	}
 
-	indexStr := strconv.Itoa(t.ChildIdx)
-	retryAttemptStr := strconv.FormatUint(t.State.RetryAttempts.GetItem(t.ChildIdx), 10)
-	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr, retryAttemptStr)
+	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), t.ChildIdx, t.State.RetryAttempts.GetItem(t.ChildIdx))
 	allocationStatus, err := allocateResource(ctx, tCtx, t.Config, podName)
 	if err != nil {
 		return LaunchError, err
@@ -187,10 +185,8 @@ func (t Task) Launch(ctx context.Context, tCtx core.TaskExecutionContext, kubeCl
 
 func (t *Task) Monitor(ctx context.Context, tCtx core.TaskExecutionContext, kubeClient core.KubeClient, dataStore *storage.DataStore, outputPrefix, baseOutputDataSandbox storage.DataReference,
 	logPlugin tasklog.Plugin) (MonitorResult, []*idlCore.TaskLog, error) {
-	indexStr := strconv.Itoa(t.ChildIdx)
 	retryAttempt := t.State.RetryAttempts.GetItem(t.ChildIdx)
-	retryAttemptStr := strconv.FormatUint(retryAttempt, 10)
-	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr, retryAttemptStr)
+	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), t.ChildIdx, retryAttempt)
 	t.SubTaskIDs = append(t.SubTaskIDs, &podName)
 	var loglinks []*idlCore.TaskLog
 
@@ -232,9 +228,7 @@ func (t *Task) Monitor(ctx context.Context, tCtx core.TaskExecutionContext, kube
 }
 
 func (t Task) Abort(ctx context.Context, tCtx core.TaskExecutionContext, kubeClient core.KubeClient) error {
-	indexStr := strconv.Itoa(t.ChildIdx)
-	retryAttemptStr := strconv.FormatUint(t.State.RetryAttempts.GetItem(t.ChildIdx), 10)
-	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr, retryAttemptStr)
+	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), t.ChildIdx, t.State.RetryAttempts.GetItem(t.ChildIdx))
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       PodKind,
@@ -260,9 +254,7 @@ func (t Task) Abort(ctx context.Context, tCtx core.TaskExecutionContext, kubeCli
 }
 
 func (t Task) Finalize(ctx context.Context, tCtx core.TaskExecutionContext, kubeClient core.KubeClient) error {
-	indexStr := strconv.Itoa(t.ChildIdx)
-	retryAttemptStr := strconv.FormatUint(t.State.RetryAttempts.GetItem(t.ChildIdx), 10)
-	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr, retryAttemptStr)
+	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), t.ChildIdx, t.State.RetryAttempts.GetItem(t.ChildIdx))
 
 	pod := &v1.Pod{
 		TypeMeta: metaV1.TypeMeta{

--- a/go/tasks/plugins/array/k8s/task.go
+++ b/go/tasks/plugins/array/k8s/task.go
@@ -188,7 +188,8 @@ func (t Task) Launch(ctx context.Context, tCtx core.TaskExecutionContext, kubeCl
 func (t *Task) Monitor(ctx context.Context, tCtx core.TaskExecutionContext, kubeClient core.KubeClient, dataStore *storage.DataStore, outputPrefix, baseOutputDataSandbox storage.DataReference,
 	logPlugin tasklog.Plugin) (MonitorResult, []*idlCore.TaskLog, error) {
 	indexStr := strconv.Itoa(t.ChildIdx)
-	retryAttemptStr := strconv.FormatUint(t.State.RetryAttempts.GetItem(t.ChildIdx), 10)
+	retryAttempt := t.State.RetryAttempts.GetItem(t.ChildIdx)
+	retryAttemptStr := strconv.FormatUint(retryAttempt, 10)
 	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr, retryAttemptStr)
 	t.SubTaskIDs = append(t.SubTaskIDs, &podName)
 	var loglinks []*idlCore.TaskLog
@@ -202,6 +203,7 @@ func (t *Task) Monitor(ctx context.Context, tCtx core.TaskExecutionContext, kube
 		},
 		originalIdx,
 		tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetID().RetryAttempt,
+		retryAttempt,
 		logPlugin)
 	if err != nil {
 		return MonitorError, loglinks, errors2.Wrapf(ErrCheckPodStatus, err, "Failed to check pod status.")

--- a/go/tasks/plugins/array/k8s/task.go
+++ b/go/tasks/plugins/array/k8s/task.go
@@ -115,7 +115,8 @@ func (t Task) Launch(ctx context.Context, tCtx core.TaskExecutionContext, kubeCl
 	}
 
 	indexStr := strconv.Itoa(t.ChildIdx)
-	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr)
+	retryAttemptStr := strconv.FormatUint(t.State.RetryAttempts.GetItem(t.ChildIdx), 10)
+	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr, retryAttemptStr)
 	allocationStatus, err := allocateResource(ctx, tCtx, t.Config, podName)
 	if err != nil {
 		return LaunchError, err
@@ -187,7 +188,8 @@ func (t Task) Launch(ctx context.Context, tCtx core.TaskExecutionContext, kubeCl
 func (t *Task) Monitor(ctx context.Context, tCtx core.TaskExecutionContext, kubeClient core.KubeClient, dataStore *storage.DataStore, outputPrefix, baseOutputDataSandbox storage.DataReference,
 	logPlugin tasklog.Plugin) (MonitorResult, []*idlCore.TaskLog, error) {
 	indexStr := strconv.Itoa(t.ChildIdx)
-	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr)
+	retryAttemptStr := strconv.FormatUint(t.State.RetryAttempts.GetItem(t.ChildIdx), 10)
+	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr, retryAttemptStr)
 	t.SubTaskIDs = append(t.SubTaskIDs, &podName)
 	var loglinks []*idlCore.TaskLog
 
@@ -229,7 +231,8 @@ func (t *Task) Monitor(ctx context.Context, tCtx core.TaskExecutionContext, kube
 
 func (t Task) Abort(ctx context.Context, tCtx core.TaskExecutionContext, kubeClient core.KubeClient) error {
 	indexStr := strconv.Itoa(t.ChildIdx)
-	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr)
+	retryAttemptStr := strconv.FormatUint(t.State.RetryAttempts.GetItem(t.ChildIdx), 10)
+	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr, retryAttemptStr)
 	pod := &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       PodKind,
@@ -256,7 +259,8 @@ func (t Task) Abort(ctx context.Context, tCtx core.TaskExecutionContext, kubeCli
 
 func (t Task) Finalize(ctx context.Context, tCtx core.TaskExecutionContext, kubeClient core.KubeClient) error {
 	indexStr := strconv.Itoa(t.ChildIdx)
-	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr)
+	retryAttemptStr := strconv.FormatUint(t.State.RetryAttempts.GetItem(t.ChildIdx), 10)
+	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr, retryAttemptStr)
 
 	pod := &v1.Pod{
 		TypeMeta: metaV1.TypeMeta{
@@ -285,7 +289,7 @@ func (t Task) Finalize(ctx context.Context, tCtx core.TaskExecutionContext, kube
 	}
 
 	// Deallocate Resource
-	err = deallocateResource(ctx, tCtx, t.Config, t.ChildIdx)
+	err = deallocateResource(ctx, tCtx, t.Config, podName)
 	if err != nil {
 		logger.Errorf(ctx, "Error releasing allocation token [%s] in Finalize [%s]", podName, err)
 		return err
@@ -317,12 +321,10 @@ func allocateResource(ctx context.Context, tCtx core.TaskExecutionContext, confi
 	return allocationStatus, nil
 }
 
-func deallocateResource(ctx context.Context, tCtx core.TaskExecutionContext, config *Config, childIdx int) error {
+func deallocateResource(ctx context.Context, tCtx core.TaskExecutionContext, config *Config, podName string) error {
 	if !IsResourceConfigSet(config.ResourceConfig) {
 		return nil
 	}
-	indexStr := strconv.Itoa((childIdx))
-	podName := formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), indexStr)
 	resourceNamespace := core.ResourceNamespace(config.ResourceConfig.PrimaryLabel)
 
 	err := tCtx.ResourceManager().ReleaseResource(ctx, resourceNamespace, podName)

--- a/go/tasks/plugins/array/k8s/task_test.go
+++ b/go/tasks/plugins/array/k8s/task_test.go
@@ -27,8 +27,8 @@ func TestFinalize(t *testing.T) {
 	resourceManager := mocks.ResourceManager{}
 	podTemplate, _, _ := FlyteArrayJobToK8sPodTemplate(ctx, tCtx, "")
 	pod := addPodFinalizer(&podTemplate)
-	pod.Name = formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), "1", "0")
-	assert.Equal(t, "notfound-1-0", pod.Name)
+	pod.Name = formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), 1, 1)
+	assert.Equal(t, "notfound-1-1", pod.Name)
 	assert.NoError(t, kubeClient.GetClient().Create(ctx, pod))
 
 	resourceManager.OnReleaseResourceMatch(mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/go/tasks/plugins/array/k8s/task_test.go
+++ b/go/tasks/plugins/array/k8s/task_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
+	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
+
+	"github.com/flyteorg/flytestdlib/bitarray"
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,8 +27,8 @@ func TestFinalize(t *testing.T) {
 	resourceManager := mocks.ResourceManager{}
 	podTemplate, _, _ := FlyteArrayJobToK8sPodTemplate(ctx, tCtx, "")
 	pod := addPodFinalizer(&podTemplate)
-	pod.Name = formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), "1")
-	assert.Equal(t, "notfound-1", pod.Name)
+	pod.Name = formatSubTaskName(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), "1", "0")
+	assert.Equal(t, "notfound-1-0", pod.Name)
 	assert.NoError(t, kubeClient.GetClient().Create(ctx, pod))
 
 	resourceManager.OnReleaseResourceMatch(mock.Anything, mock.Anything, mock.Anything).Return(nil)
@@ -39,12 +42,20 @@ func TestFinalize(t *testing.T) {
 		},
 	}
 
+	retryAttemptsArray, err := bitarray.NewCompactArray(2, 1)
+	assert.NoError(t, err)
+
+	state := core.State{
+		RetryAttempts: retryAttemptsArray,
+	}
+
 	task := &Task{
+		State:    &state,
 		Config:   &config,
 		ChildIdx: 1,
 	}
 
-	err := task.Finalize(ctx, tCtx, &kubeClient)
+	err = task.Finalize(ctx, tCtx, &kubeClient)
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
# TL;DR
Currently, k8s array tasks (map tasks) retry the entire collection of subtasks when one of them fails. This PR enables retries over individual subtasks.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
A previous [PR](https://github.com/flyteorg/flyteplugins/pull/231) added tracking of retry attempts for each subtask. As the current implementation retries all subtasks if one fails, this wasn't particularly useful because they were all the same. With this PR we enable subtasks to be retried individually, using this retry attempts array to inform unique pod names and logs for each subtask retry.

When a subtask fails, the current implementation reports the failure (as retryable) to the parent map task. Now we attempt to retry by incrementing the retry attempt value and transitioning the subtask to the "Undefined" phase as if it had never been executed. This is recognized during the next evaluation and another attempt is executed.

We use the max attempts defined on the parent map task to determine the number of times a subtask may be executed. As we track subtask retries internally (rather than within the parent map task), if a subtask exceeds the maximum number of retries we report a permanent failure to the parent map task. This ensure that the entire collection of subtasks is not retried again (with each subtask potentially retried multiple more times). Other retryable failures reported to the map task will still fallthrough.

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/1276

## Follow-up issue
- https://github.com/flyteorg/flyte/issues/1533: This solution does not fix any issues with interruptible nodes within k8s array tasks. Will have to be addressed separately. Discerning what is an interrupted failure is very difficult, the current approach handles all "system" failures as interrupted and enables a different configurable number of retries. We might need to track the failure type as well?
