### PR TITLE
Add support for handling of node interruption events in Kubernetes plugin

### DIFF
--- a/boilerplate/flyte/golang_support_tools/tools.go
+++ b/boilerplate/flyte/golang_support_tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools
@@ -6,6 +7,6 @@ import (
 	_ "github.com/alvaroloes/enumer"
 	_ "github.com/flyteorg/flytestdlib/cli/pflags"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
-	_ "github.com/vektra/mockery/cmd/mockery"
 	_ "github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc"
+	_ "github.com/vektra/mockery/cmd/mockery"
 )

--- a/go/tasks/plugins/array/k8s/monitor.go
+++ b/go/tasks/plugins/array/k8s/monitor.go
@@ -267,8 +267,7 @@ func FetchPodStatusAndLogs(ctx context.Context, client core.KubeClient, name k8s
 	case v1.PodSucceeded:
 		phaseInfo, err2 = flytek8s.DemystifySuccess(pod.Status, taskInfo)
 	case v1.PodFailed:
-		code, message := flytek8s.ConvertPodFailureToError(pod.Status)
-		phaseInfo = core.PhaseInfoRetryableFailure(code, message, &taskInfo)
+		phaseInfo, err2 = flytek8s.DemystifyFailure(pod.Status, taskInfo)
 	case v1.PodPending:
 		phaseInfo, err2 = flytek8s.DemystifyPending(pod.Status)
 	case v1.PodUnknown:

--- a/go/tasks/plugins/k8s/pod/plugin.go
+++ b/go/tasks/plugins/k8s/pod/plugin.go
@@ -95,8 +95,7 @@ func (plugin) GetTaskPhase(ctx context.Context, pluginContext k8s.PluginContext,
 	case v1.PodSucceeded:
 		return flytek8s.DemystifySuccess(pod.Status, info)
 	case v1.PodFailed:
-		code, message := flytek8s.ConvertPodFailureToError(pod.Status)
-		return pluginsCore.PhaseInfoRetryableFailure(code, message, &info), nil
+		return flytek8s.DemystifyFailure(pod.Status, info)
 	case v1.PodPending:
 		return flytek8s.DemystifyPending(pod.Status)
 	case v1.PodReasonUnschedulable:


### PR DESCRIPTION
# TL;DR
This PR adds detection of pod failures due to node interruption, initially on GKE >= 1.20. This is required for `interruptible-failure-threshold` to be effective.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Refactored `ConvertPodFailureToError` to `DemystifyFailure` to be consistent with other methods, and return `PhaseInfoSystemRetryableFailure` on pod failures due to interruption.

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
