### PR TITLE
Track parallelism in k8s array plugin

### DIFF
--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -144,7 +144,7 @@ func ToArrayJob(structObj *structpb.Struct, taskTypeVersion int32) (*idlPlugins.
 		if taskTypeVersion == 0 {
 
 			return &idlPlugins.ArrayJob{
-				Parallelism: 1,
+				Parallelism: 0,
 				Size:        1,
 				SuccessCriteria: &idlPlugins.ArrayJob_MinSuccesses{
 					MinSuccesses: 1,
@@ -152,7 +152,7 @@ func ToArrayJob(structObj *structpb.Struct, taskTypeVersion int32) (*idlPlugins.
 			}, nil
 		}
 		return &idlPlugins.ArrayJob{
-			Parallelism: 1,
+			Parallelism: 0,
 			Size:        1,
 			SuccessCriteria: &idlPlugins.ArrayJob_MinSuccessRatio{
 				MinSuccessRatio: 1.0,

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -142,7 +142,6 @@ const (
 func ToArrayJob(structObj *structpb.Struct, taskTypeVersion int32) (*idlPlugins.ArrayJob, error) {
 	if structObj == nil {
 		if taskTypeVersion == 0 {
-
 			return &idlPlugins.ArrayJob{
 				Parallelism: 0,
 				Size:        1,

--- a/go/tasks/plugins/array/core/state_test.go
+++ b/go/tasks/plugins/array/core/state_test.go
@@ -295,7 +295,7 @@ func TestToArrayJob(t *testing.T) {
 		arrayJob, err := ToArrayJob(nil, 0)
 		assert.NoError(t, err)
 		assert.True(t, proto.Equal(arrayJob, &plugins.ArrayJob{
-			Parallelism: 1,
+			Parallelism: 0,
 			Size:        1,
 			SuccessCriteria: &plugins.ArrayJob_MinSuccesses{
 				MinSuccesses: 1,
@@ -307,7 +307,7 @@ func TestToArrayJob(t *testing.T) {
 		arrayJob, err := ToArrayJob(nil, 1)
 		assert.NoError(t, err)
 		assert.True(t, proto.Equal(arrayJob, &plugins.ArrayJob{
-			Parallelism: 1,
+			Parallelism: 0,
 			Size:        1,
 			SuccessCriteria: &plugins.ArrayJob_MinSuccessRatio{
 				MinSuccessRatio: 1.0,

--- a/go/tasks/plugins/array/k8s/monitor.go
+++ b/go/tasks/plugins/array/k8s/monitor.go
@@ -192,13 +192,13 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		// validate map task parallelism
 		newSubtaskPhase := core.Phases[newArrayStatus.Detailed.GetItem(childIdx)]
 		if !newSubtaskPhase.IsTerminal() || newSubtaskPhase == core.PhaseRetryableFailure {
-			currentParallelism += 1
+			currentParallelism++
 		}
 
 		if maxParallelism != 0 && currentParallelism >= maxParallelism {
 			// If max parallelism has been achieved we need to fill the subtask phase summary with
-			// the remaining subtasks so the overall map task phase can be accurately identified. 
-			for i := childIdx+1; i<len(currentState.GetArrayStatus().Detailed.GetItems()); i++ {
+			// the remaining subtasks so the overall map task phase can be accurately identified.
+			for i := childIdx + 1; i < len(currentState.GetArrayStatus().Detailed.GetItems()); i++ {
 				childSubtaskPhase := core.Phases[newArrayStatus.Detailed.GetItem(i)]
 				newArrayStatus.Summary.Inc(childSubtaskPhase)
 			}

--- a/go/tasks/plugins/array/k8s/monitor.go
+++ b/go/tasks/plugins/array/k8s/monitor.go
@@ -6,30 +6,27 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/tasklog"
+	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 
+	"github.com/flyteorg/flyteplugins/go/tasks/errors"
+	"github.com/flyteorg/flyteplugins/go/tasks/logs"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/tasklog"
+	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array/arraystatus"
+	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
+	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array/errorcollector"
+
+	"github.com/flyteorg/flytestdlib/bitarray"
 	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/storage"
 
-	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
-
-	"github.com/flyteorg/flytestdlib/bitarray"
-
-	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array/arraystatus"
-	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array/errorcollector"
-
 	v1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
 
-	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s"
-
-	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	errors2 "github.com/flyteorg/flytestdlib/errors"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-
-	"github.com/flyteorg/flyteplugins/go/tasks/logs"
-	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 )
 
 const (
@@ -90,6 +87,22 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		logger.Errorf(ctx, "Error initializing LogPlugins: [%s]", err)
 		return currentState, logLinks, subTaskIDs, err
 	}
+
+	// identify max parallelism
+	taskTemplate, err := tCtx.TaskReader().Read(ctx)
+	if err != nil {
+		return currentState, logLinks, subTaskIDs, err
+	} else if taskTemplate == nil {
+		return currentState, logLinks, subTaskIDs, errors.Errorf(errors.BadTaskSpecification, "Required value not set, taskTemplate is nil")
+	}
+
+	arrayJob, err := arrayCore.ToArrayJob(taskTemplate.GetCustom(), taskTemplate.TaskTypeVersion)
+	if err != nil {
+		return currentState, logLinks, subTaskIDs, err
+	}
+
+	currentParallelism := 0
+	maxParallelism := int(arrayJob.Parallelism)
 
 	for childIdx, existingPhaseIdx := range currentState.GetArrayStatus().Detailed.GetItems() {
 		existingPhase := core.Phases[existingPhaseIdx]
@@ -175,17 +188,26 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 			}
 			return currentState, logLinks, subTaskIDs, err
 		}
+
+		// validate map task parallelism
+		newSubtaskPhase := core.Phases[newArrayStatus.Detailed.GetItem(childIdx)]
+		if !newSubtaskPhase.IsTerminal() || newSubtaskPhase == core.PhaseRetryableFailure {
+			currentParallelism += 1
+		}
+
+		if maxParallelism != 0 && currentParallelism >= maxParallelism {
+			// If max parallelism has been achieved we need to fill the subtask phase summary with
+			// the remaining subtasks so the overall map task phase can be accurately identified. 
+			for i := childIdx+1; i<len(currentState.GetArrayStatus().Detailed.GetItems()); i++ {
+				childSubtaskPhase := core.Phases[newArrayStatus.Detailed.GetItem(i)]
+				newArrayStatus.Summary.Inc(childSubtaskPhase)
+			}
+
+			break
+		}
 	}
 
 	newState = newState.SetArrayStatus(*newArrayStatus)
-
-	// Check that the taskTemplate is valid
-	taskTemplate, err := tCtx.TaskReader().Read(ctx)
-	if err != nil {
-		return currentState, logLinks, subTaskIDs, err
-	} else if taskTemplate == nil {
-		return currentState, logLinks, subTaskIDs, fmt.Errorf("required value not set, taskTemplate is nil")
-	}
 
 	phase := arrayCore.SummaryToPhase(ctx, currentState.GetOriginalMinSuccesses()-currentState.GetOriginalArraySize()+int64(currentState.GetExecutionArraySize()), newArrayStatus.Summary)
 	if phase == arrayCore.PhaseWriteToDiscoveryThenFail {

--- a/go/tasks/plugins/array/k8s/monitor_test.go
+++ b/go/tasks/plugins/array/k8s/monitor_test.go
@@ -254,8 +254,8 @@ func TestCheckSubTasksStateParallelism(t *testing.T) {
 			newState, _, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", &arrayCore.State{
 				CurrentPhase:         arrayCore.PhaseCheckingSubTaskExecutions,
 				ExecutionArraySize:   subtaskCount,
-				OriginalArraySize:    int64(subtaskCount*2),
-				OriginalMinSuccesses: int64(subtaskCount*2),
+				OriginalArraySize:    int64(subtaskCount * 2),
+				OriginalMinSuccesses: int64(subtaskCount * 2),
 				IndexesToCache:       cacheIndexes,
 				ArrayStatus: arraystatus.ArrayStatus{
 					Detailed: arrayCore.NewPhasesCompactArray(uint(subtaskCount)),

--- a/go/tasks/plugins/array/k8s/monitor_test.go
+++ b/go/tasks/plugins/array/k8s/monitor_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
+
+	structpb "google.golang.org/protobuf/types/known/structpb"
 )
 
 func createSampleContainerTask() *core2.Container {
@@ -33,9 +35,14 @@ func createSampleContainerTask() *core2.Container {
 	}
 }
 
-func getMockTaskExecutionContext(ctx context.Context) *mocks.TaskExecutionContext {
+func getMockTaskExecutionContext(ctx context.Context, parallelism int) *mocks.TaskExecutionContext {
+	customStruct, _ := structpb.NewStruct(map[string]interface{}{
+		"parallelism": fmt.Sprintf("%d", parallelism),
+	})
+
 	tr := &mocks.TaskReader{}
 	tr.OnRead(ctx).Return(&core2.TaskTemplate{
+		Custom: customStruct,
 		Target: &core2.TaskTemplate_Container{
 			Container: createSampleContainerTask(),
 		},
@@ -103,7 +110,7 @@ func getMockTaskExecutionContext(ctx context.Context) *mocks.TaskExecutionContex
 
 func TestGetNamespaceForExecution(t *testing.T) {
 	ctx := context.Background()
-	tCtx := getMockTaskExecutionContext(ctx)
+	tCtx := getMockTaskExecutionContext(ctx, 0)
 
 	assert.Equal(t, GetNamespaceForExecution(tCtx, ""), tCtx.TaskExecutionMetadata().GetNamespace())
 	assert.Equal(t, GetNamespaceForExecution(tCtx, "abcd"), "abcd")
@@ -122,7 +129,7 @@ func testSubTaskIDs(t *testing.T, actual []*string) {
 func TestCheckSubTasksState(t *testing.T) {
 	ctx := context.Background()
 
-	tCtx := getMockTaskExecutionContext(ctx)
+	tCtx := getMockTaskExecutionContext(ctx, 0)
 	kubeClient := mocks.KubeClient{}
 	kubeClient.OnGetClient().Return(mocks.NewFakeKubeClient())
 	kubeClient.OnGetCache().Return(mocks.NewFakeKubeCache())
@@ -218,10 +225,65 @@ func TestCheckSubTasksState(t *testing.T) {
 	})
 }
 
+func TestCheckSubTasksStateParallelism(t *testing.T) {
+	subtaskCount := 5
+
+	for i := 1; i <= subtaskCount; i++ {
+		t.Run(fmt.Sprintf("Parallelism-%d", i), func(t *testing.T) {
+			// construct task context
+			ctx := context.Background()
+
+			tCtx := getMockTaskExecutionContext(ctx, i)
+			kubeClient := mocks.KubeClient{}
+			kubeClient.OnGetClient().Return(mocks.NewFakeKubeClient())
+			kubeClient.OnGetCache().Return(mocks.NewFakeKubeCache())
+
+			resourceManager := mocks.ResourceManager{}
+			resourceManager.OnAllocateResourceMatch(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(core.AllocationStatusExhausted, nil)
+			tCtx.OnResourceManager().Return(&resourceManager)
+
+			// evaluate one round of subtask launch and monitor
+			config := Config{
+				MaxArrayJobSize: 100,
+			}
+
+			retryAttemptsArray, err := bitarray.NewCompactArray(uint(subtaskCount), bitarray.Item(0))
+			assert.NoError(t, err)
+
+			cacheIndexes := bitarray.NewBitSet(uint(subtaskCount))
+			newState, _, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", &arrayCore.State{
+				CurrentPhase:         arrayCore.PhaseCheckingSubTaskExecutions,
+				ExecutionArraySize:   subtaskCount,
+				OriginalArraySize:    int64(subtaskCount*2),
+				OriginalMinSuccesses: int64(subtaskCount*2),
+				IndexesToCache:       cacheIndexes,
+				ArrayStatus: arraystatus.ArrayStatus{
+					Detailed: arrayCore.NewPhasesCompactArray(uint(subtaskCount)),
+				},
+				RetryAttempts: retryAttemptsArray,
+			})
+
+			assert.Nil(t, err)
+			p, _ := newState.GetPhase()
+			assert.Equal(t, arrayCore.PhaseCheckingSubTaskExecutions.String(), p.String())
+
+			// validate only i subtasks were processed
+			executed := 0
+			for _, existingPhaseIdx := range newState.GetArrayStatus().Detailed.GetItems() {
+				if core.Phases[existingPhaseIdx] != core.PhaseUndefined {
+					executed++
+				}
+			}
+
+			assert.Equal(t, i, executed)
+		})
+	}
+}
+
 func TestCheckSubTasksStateResourceGranted(t *testing.T) {
 	ctx := context.Background()
 
-	tCtx := getMockTaskExecutionContext(ctx)
+	tCtx := getMockTaskExecutionContext(ctx, 0)
 	kubeClient := mocks.KubeClient{}
 	kubeClient.OnGetClient().Return(mocks.NewFakeKubeClient())
 	kubeClient.OnGetCache().Return(mocks.NewFakeKubeCache())

--- a/go/tasks/plugins/array/k8s/task_test.go
+++ b/go/tasks/plugins/array/k8s/task_test.go
@@ -17,7 +17,7 @@ import (
 func TestFinalize(t *testing.T) {
 	ctx := context.Background()
 
-	tCtx := getMockTaskExecutionContext(ctx)
+	tCtx := getMockTaskExecutionContext(ctx, 0)
 	kubeClient := mocks.KubeClient{}
 	kubeClient.OnGetClient().Return(mocks.NewFakeKubeClient())
 


### PR DESCRIPTION
# TL;DR
Currently the concurrency / parallelism parameter on the k8s array plugin is non-functional. This means concurrency controls on map tasks do not work as expected. This PR enables tracking and validating parallelism constraints during k8s array plugin evaluations by tracking non-terminal subtask phases.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2121

## Follow-up issue
_NA_
