### PR TITLE
#minor Allows creating multiple webapi plugins

### DIFF
--- a/go/tasks/pluginmachinery/internal/webapi/core.go
+++ b/go/tasks/pluginmachinery/internal/webapi/core.go
@@ -191,7 +191,7 @@ func createRemotePlugin(pluginEntry webapi.PluginEntry, c clock.Clock) core.Plug
 			}
 
 			resourceCache, err := NewResourceCache(ctx, pluginEntry.ID, p, p.GetConfig().Caching,
-				iCtx.MetricsScope().NewSubScope("cache"))
+				iCtx.MetricsScope().NewSubScope(pluginEntry.ID).NewSubScope("cache"))
 
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Signed-off-by: Ketan Umare <ketan.umare@gmail.com>

# TL;DR
 - Currently webapi plugins cannot be created, because they conflict for
cache metrics
 - this creates a new subscope with the plugin id

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue


## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2136

## Follow-up issue
_NA_

