### PR TITLE
Ensure Athena Plugin ClientRequestToken is within allowed limits

### DIFF
--- a/go/tasks/logs/logconfig_flags.go
+++ b/go/tasks/logs/logconfig_flags.go
@@ -50,16 +50,16 @@ func (LogConfig) mustMarshalJSON(v json.Marshaler) string {
 // flags is json-name.json-sub-name... etc.
 func (cfg LogConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("LogConfig", pflag.ExitOnError)
-	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "cloudwatch-enabled"), *new(bool), "Enable Cloudwatch Logging")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cloudwatch-region"), *new(string), "AWS region in which Cloudwatch logs are stored.")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cloudwatch-log-group"), *new(string), "Log group to which streams are associated.")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cloudwatch-template-uri"), *new(string), "Template Uri to use when building cloudwatch log links")
-	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "kubernetes-enabled"), *new(bool), "Enable Kubernetes Logging")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kubernetes-url"), *new(string), "Console URL for Kubernetes logs")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kubernetes-template-uri"), *new(string), "Template Uri to use when building kubernetes log links")
-	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "stackdriver-enabled"), *new(bool), "Enable Log-links to stackdriver")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gcp-project"), *new(string), "Name of the project in GCP")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "stackdriver-logresourcename"), *new(string), "Name of the logresource in stackdriver")
-	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "stackdriver-template-uri"), *new(string), "Template Uri to use when building stackdriver log links")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "cloudwatch-enabled"), DefaultConfig.IsCloudwatchEnabled, "Enable Cloudwatch Logging")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cloudwatch-region"), DefaultConfig.CloudwatchRegion, "AWS region in which Cloudwatch logs are stored.")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cloudwatch-log-group"), DefaultConfig.CloudwatchLogGroup, "Log group to which streams are associated.")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "cloudwatch-template-uri"), DefaultConfig.CloudwatchTemplateURI, "Template Uri to use when building cloudwatch log links")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "kubernetes-enabled"), DefaultConfig.IsKubernetesEnabled, "Enable Kubernetes Logging")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kubernetes-url"), DefaultConfig.KubernetesURL, "Console URL for Kubernetes logs")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kubernetes-template-uri"), DefaultConfig.KubernetesTemplateURI, "Template Uri to use when building kubernetes log links")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "stackdriver-enabled"), DefaultConfig.IsStackDriverEnabled, "Enable Log-links to stackdriver")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "gcp-project"), DefaultConfig.GCPProjectName, "Name of the project in GCP")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "stackdriver-logresourcename"), DefaultConfig.StackdriverLogResourceName, "Name of the logresource in stackdriver")
+	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "stackdriver-template-uri"), DefaultConfig.StackDriverTemplateURI, "Template Uri to use when building stackdriver log links")
 	return cmdFlags
 }

--- a/go/tasks/pluginmachinery/core/exec_metadata.go
+++ b/go/tasks/pluginmachinery/core/exec_metadata.go
@@ -21,7 +21,7 @@ type TaskExecutionID interface {
 
 	// GetGeneratedNameWith returns the generated name within a bounded length. If the name is smaller than minLength,
 	// it'll get right-padded with character '0'. If the name is bigger than maxLength, it'll get hashed to fit within.
-	GetGeneratedNameWith(minLength, maxLength uint) string
+	GetGeneratedNameWith(minLength, maxLength int) (string, error)
 
 	// GetID returns the underlying idl task identifier.
 	GetID() core.TaskExecutionIdentifier

--- a/go/tasks/pluginmachinery/core/exec_metadata.go
+++ b/go/tasks/pluginmachinery/core/exec_metadata.go
@@ -7,24 +7,32 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// Interface to expose any overrides that have been set for this task (like resource overrides etc)
+// TaskOverrides interface to expose any overrides that have been set for this task (like resource overrides etc)
 type TaskOverrides interface {
 	GetResources() *v1.ResourceRequirements
 	GetConfig() *v1.ConfigMap
 }
 
-// Simple Interface to expose the ExecutionID of the running Task
+// TaskExecutionID is a simple Interface to expose the ExecutionID of the running Task
 type TaskExecutionID interface {
+	// GetGeneratedName returns the computed/generated name for the task id
+	// deprecated: use GetGeneratedNameWithLength
 	GetGeneratedName() string
+
+	// GetGeneratedNameWith returns the generated name within a bounded length. If the name is smaller than minLength,
+	// it'll get right-padded with character '0'. If the name is bigger than maxLength, it'll get hashed to fit within.
+	GetGeneratedNameWith(minLength, maxLength uint) string
+
+	// GetID returns the underlying idl task identifier.
 	GetID() core.TaskExecutionIdentifier
 }
 
-// TaskContext represents any execution information for a Task. It is used to communicate meta information about the
+// TaskExecutionMetadata represents any execution information for a Task. It is used to communicate meta information about the
 // execution or any previously stored information
 type TaskExecutionMetadata interface {
-	// The owning Kubernetes object
+	// GetOwnerID returns the owning Kubernetes object
 	GetOwnerID() types.NamespacedName
-	// A specially generated task execution id, that is guaranteed to be unique and consistent for subsequent calls
+	// GetTaskExecutionID is a specially generated task execution id, that is guaranteed to be unique and consistent for subsequent calls
 	GetTaskExecutionID() TaskExecutionID
 	GetNamespace() string
 	GetOwnerReference() v12.OwnerReference

--- a/go/tasks/pluginmachinery/core/mocks/task_execution_id.go
+++ b/go/tasks/pluginmachinery/core/mocks/task_execution_id.go
@@ -48,11 +48,11 @@ type TaskExecutionID_GetGeneratedNameWith struct {
 	*mock.Call
 }
 
-func (_m TaskExecutionID_GetGeneratedNameWith) Return(_a0 string) *TaskExecutionID_GetGeneratedNameWith {
-	return &TaskExecutionID_GetGeneratedNameWith{Call: _m.Call.Return(_a0)}
+func (_m TaskExecutionID_GetGeneratedNameWith) Return(_a0 string, _a1 error) *TaskExecutionID_GetGeneratedNameWith {
+	return &TaskExecutionID_GetGeneratedNameWith{Call: _m.Call.Return(_a0, _a1)}
 }
 
-func (_m *TaskExecutionID) OnGetGeneratedNameWith(minLength uint, maxLength uint) *TaskExecutionID_GetGeneratedNameWith {
+func (_m *TaskExecutionID) OnGetGeneratedNameWith(minLength int, maxLength int) *TaskExecutionID_GetGeneratedNameWith {
 	c := _m.On("GetGeneratedNameWith", minLength, maxLength)
 	return &TaskExecutionID_GetGeneratedNameWith{Call: c}
 }
@@ -63,17 +63,24 @@ func (_m *TaskExecutionID) OnGetGeneratedNameWithMatch(matchers ...interface{}) 
 }
 
 // GetGeneratedNameWith provides a mock function with given fields: minLength, maxLength
-func (_m *TaskExecutionID) GetGeneratedNameWith(minLength uint, maxLength uint) string {
+func (_m *TaskExecutionID) GetGeneratedNameWith(minLength int, maxLength int) (string, error) {
 	ret := _m.Called(minLength, maxLength)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(uint, uint) string); ok {
+	if rf, ok := ret.Get(0).(func(int, int) string); ok {
 		r0 = rf(minLength, maxLength)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	return r0
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int, int) error); ok {
+		r1 = rf(minLength, maxLength)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 type TaskExecutionID_GetID struct {

--- a/go/tasks/pluginmachinery/core/mocks/task_execution_id.go
+++ b/go/tasks/pluginmachinery/core/mocks/task_execution_id.go
@@ -44,6 +44,38 @@ func (_m *TaskExecutionID) GetGeneratedName() string {
 	return r0
 }
 
+type TaskExecutionID_GetGeneratedNameWith struct {
+	*mock.Call
+}
+
+func (_m TaskExecutionID_GetGeneratedNameWith) Return(_a0 string) *TaskExecutionID_GetGeneratedNameWith {
+	return &TaskExecutionID_GetGeneratedNameWith{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *TaskExecutionID) OnGetGeneratedNameWith(minLength uint, maxLength uint) *TaskExecutionID_GetGeneratedNameWith {
+	c := _m.On("GetGeneratedNameWith", minLength, maxLength)
+	return &TaskExecutionID_GetGeneratedNameWith{Call: c}
+}
+
+func (_m *TaskExecutionID) OnGetGeneratedNameWithMatch(matchers ...interface{}) *TaskExecutionID_GetGeneratedNameWith {
+	c := _m.On("GetGeneratedNameWith", matchers...)
+	return &TaskExecutionID_GetGeneratedNameWith{Call: c}
+}
+
+// GetGeneratedNameWith provides a mock function with given fields: minLength, maxLength
+func (_m *TaskExecutionID) GetGeneratedNameWith(minLength uint, maxLength uint) string {
+	ret := _m.Called(minLength, maxLength)
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func(uint, uint) string); ok {
+		r0 = rf(minLength, maxLength)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 type TaskExecutionID_GetID struct {
 	*mock.Call
 }

--- a/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds_test.go
@@ -221,6 +221,10 @@ func (m mockTaskExecutionIdentifier) GetID() core.TaskExecutionIdentifier {
 	return testTaskExecutionIdentifier
 }
 
+func (m mockTaskExecutionIdentifier) GetGeneratedNameWith(minLength, maxLength int) (string, error) {
+	return "task-exec-name", nil
+}
+
 func (m mockTaskExecutionIdentifier) GetGeneratedName() string {
 	return "task-exec-name"
 }

--- a/go/tasks/plugins/array/awsbatch/mocks/client.go
+++ b/go/tasks/plugins/array/awsbatch/mocks/client.go
@@ -138,7 +138,7 @@ func (_m *Client) OnRegisterJobDefinitionMatch(matchers ...interface{}) *Client_
 	return &Client_RegisterJobDefinition{Call: c}
 }
 
-// RegisterJobDefinition provides a mock function with given fields: ctx, name, image, role, structObj
+// RegisterJobDefinition provides a mock function with given fields: ctx, name, image, role, platformCapabilities
 func (_m *Client) RegisterJobDefinition(ctx context.Context, name string, image string, role string, platformCapabilities string) (string, error) {
 	ret := _m.Called(ctx, name, image, role, platformCapabilities)
 

--- a/go/tasks/plugins/webapi/athena/plugin.go
+++ b/go/tasks/plugins/webapi/athena/plugin.go
@@ -73,10 +73,17 @@ func (p Plugin) Create(ctx context.Context, tCtx webapi.TaskExecutionContextRead
 		return nil, nil, errors.Errorf(errors2.BadTaskSpecification, "Database must not be empty.")
 	}
 
+	// https://docs.aws.amazon.com/athena/latest/APIReference/API_StartQueryExecution.html dictates that the length
+	// must be within the range [32, 128].
+	clientRequestToken, err := tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedNameWith(32, 128)
+	if err != nil {
+		return nil, nil, errors.Wrapf(errors2.BadTaskSpecification, err,
+			"Generated Name [%v] couldn't be converted to a ClientRequestToken",
+			tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName())
+	}
+
 	resp, err := p.client.StartQueryExecution(ctx, &athena.StartQueryExecutionInput{
-		// https://docs.aws.amazon.com/athena/latest/APIReference/API_StartQueryExecution.html dictates that the length
-		// must be within the range [32, 128].
-		ClientRequestToken: awsSdk.String(tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedNameWith(32, 128)),
+		ClientRequestToken: awsSdk.String(clientRequestToken),
 		QueryExecutionContext: &athenaTypes.QueryExecutionContext{
 			Database: awsSdk.String(queryInfo.Database),
 			Catalog:  awsSdk.String(queryInfo.Catalog),

--- a/go/tasks/plugins/webapi/athena/plugin.go
+++ b/go/tasks/plugins/webapi/athena/plugin.go
@@ -73,9 +73,10 @@ func (p Plugin) Create(ctx context.Context, tCtx webapi.TaskExecutionContextRead
 		return nil, nil, errors.Errorf(errors2.BadTaskSpecification, "Database must not be empty.")
 	}
 
-	execID := tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetID().NodeExecutionId.GetExecutionId()
 	resp, err := p.client.StartQueryExecution(ctx, &athena.StartQueryExecutionInput{
-		ClientRequestToken: awsSdk.String(fmt.Sprintf("%v-%v-%v", execID.Project, execID.Domain, tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName())),
+		// https://docs.aws.amazon.com/athena/latest/APIReference/API_StartQueryExecution.html dictates that the length
+		// must be within the range [32, 128].
+		ClientRequestToken: awsSdk.String(tCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedNameWith(32, 128)),
 		QueryExecutionContext: &athenaTypes.QueryExecutionContext{
 			Database: awsSdk.String(queryInfo.Database),
 			Catalog:  awsSdk.String(queryInfo.Catalog),


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
https://docs.aws.amazon.com/athena/latest/APIReference/API_StartQueryExecution.html dictates that ClientRequestToken size must be within the [32, 128] range.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

fixes https://github.com/flyteorg/flyte/issues/<number>
