### PR TITLE
sending all subtask info on map task start

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,3 +50,5 @@ require (
 )
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
+
+replace github.com/flyteorg/flyteidl => github.com/flyteorg/flyteidl v0.24.7-0.20220325151357-3a5050675a3b

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.2.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4
-	github.com/imdario/mergo v0.3.11 // indirect
+	github.com/imdario/mergo v0.3.11
 	github.com/kubeflow/common v0.4.0
 	github.com/kubeflow/mpi-operator/v2 v2.0.0-20210920181600-c5c0c3ef99ec
 	github.com/kubeflow/pytorch-operator v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.0.0
 	github.com/aws/aws-sdk-go-v2/service/athena v1.0.0
 	github.com/coocood/freecache v1.1.1
-	github.com/flyteorg/flyteidl v0.23.0
+	github.com/flyteorg/flyteidl v0.24.7
 	github.com/flyteorg/flytestdlib v0.4.13
 	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/go-test/deep v1.0.7
@@ -50,5 +50,3 @@ require (
 )
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
-
-replace github.com/flyteorg/flyteidl => github.com/flyteorg/flyteidl v0.24.7-0.20220325151357-3a5050675a3b

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
-github.com/flyteorg/flyteidl v0.24.7-0.20220325151357-3a5050675a3b h1:G/WaK2h/ysdVLDPbkS6XWmFVTla0YUX8bhCYYRq8ayg=
-github.com/flyteorg/flyteidl v0.24.7-0.20220325151357-3a5050675a3b/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
+github.com/flyteorg/flyteidl v0.24.7 h1:J9Wnk+JHpbRxOVs5moehQ7BRsZefsdABYuRYinXih8c=
+github.com/flyteorg/flyteidl v0.24.7/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/flyteorg/flytestdlib v0.4.13 h1:TzgqhECRGfOHYH1A7rUwcKEEH2rTtPxGy+oYcif7iBw=
 github.com/flyteorg/flytestdlib v0.4.13/go.mod h1:fv1ar34LJLMTaf0tbfetisLykUlARi7rP+NQTUn6QQs=

--- a/go.sum
+++ b/go.sum
@@ -233,8 +233,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
-github.com/flyteorg/flyteidl v0.23.0 h1:Pjl9Tq1pJfIK0au5PiqPVpl25xTYosN6BruZl+PgWAk=
-github.com/flyteorg/flyteidl v0.23.0/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
+github.com/flyteorg/flyteidl v0.24.7-0.20220325151357-3a5050675a3b h1:G/WaK2h/ysdVLDPbkS6XWmFVTla0YUX8bhCYYRq8ayg=
+github.com/flyteorg/flyteidl v0.24.7-0.20220325151357-3a5050675a3b/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/flyteorg/flytestdlib v0.4.13 h1:TzgqhECRGfOHYH1A7rUwcKEEH2rTtPxGy+oYcif7iBw=
 github.com/flyteorg/flytestdlib v0.4.13/go.mod h1:fv1ar34LJLMTaf0tbfetisLykUlARi7rP+NQTUn6QQs=

--- a/go/tasks/pluginmachinery/core/phase.go
+++ b/go/tasks/pluginmachinery/core/phase.go
@@ -70,10 +70,14 @@ func (p Phase) IsWaitingForResources() bool {
 type ExternalResource struct {
 	// A unique identifier for the external resource
 	ExternalID string
+	// TODO hamersaw - document
+	CacheStatus core.CatalogCacheStatus
 	// A unique index for the external resource. Although the ID may change, this will remain the same
 	// throughout task event reports and retries.
 	Index uint32
-	// The nubmer of times this external resource has been attempted
+	// TODO hamersaw - document
+	Logs []*core.TaskLog
+	// The number of times this external resource has been attempted
 	RetryAttempt uint32
 	// Phase (if exists) associated with the external resource
 	Phase Phase

--- a/go/tasks/pluginmachinery/core/phase.go
+++ b/go/tasks/pluginmachinery/core/phase.go
@@ -70,12 +70,12 @@ func (p Phase) IsWaitingForResources() bool {
 type ExternalResource struct {
 	// A unique identifier for the external resource
 	ExternalID string
-	// TODO hamersaw - document
+	// Captures the status of caching for this external resource
 	CacheStatus core.CatalogCacheStatus
 	// A unique index for the external resource. Although the ID may change, this will remain the same
 	// throughout task event reports and retries.
 	Index uint32
-	// TODO hamersaw - document
+	// Log information for the external resource
 	Logs []*core.TaskLog
 	// The number of times this external resource has been attempted
 	RetryAttempt uint32

--- a/go/tasks/plugins/array/awsbatch/executor.go
+++ b/go/tasks/plugins/array/awsbatch/executor.go
@@ -112,7 +112,9 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 	case arrayCore.PhaseStart:
 		externalResources, err = arrayCore.InitializeSubTaskMetadata(ctx, tCtx, pluginState.State,
 			func(tCtx core.TaskExecutionContext, childIndex int) string {
-				return "" // TODO hamersaw - generate temporary subTaskID for aws_batch plugin
+				// subTaskIDs for the the aws_batch are generated based on the job ID, therefore
+				// to initialize we default to an empty string which will be updated later.
+				return ""
 			},
 		)
 	default:

--- a/go/tasks/plugins/array/awsbatch/executor.go
+++ b/go/tasks/plugins/array/awsbatch/executor.go
@@ -110,7 +110,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 	var externalResources []*core.ExternalResource
 	switch p {
 	case arrayCore.PhaseStart:
-		externalResources, err = arrayCore.InitializeSubTaskMetadata(ctx, tCtx, pluginState.State,
+		externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, pluginState.State,
 			func(tCtx core.TaskExecutionContext, childIndex int) string {
 				// subTaskIDs for the the aws_batch are generated based on the job ID, therefore
 				// to initialize we default to an empty string which will be updated later.

--- a/go/tasks/plugins/array/awsbatch/executor.go
+++ b/go/tasks/plugins/array/awsbatch/executor.go
@@ -107,16 +107,16 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 
 	// Always attempt to augment phase with task logs.
 	var logLinks []*idlCore.TaskLog
-	var subTaskMetadata []*arrayCore.SubTaskMetadata
+	var externalResources []*core.ExternalResource
 	switch p {
 	case arrayCore.PhaseStart:
-		subTaskMetadata, err = arrayCore.InitializeSubTaskMetadata(ctx, tCtx, pluginState.State,
+		externalResources, err = arrayCore.InitializeSubTaskMetadata(ctx, tCtx, pluginState.State,
 			func(tCtx core.TaskExecutionContext, childIndex int) string {
 				return "" // TODO hamersaw - generate temporary subTaskID for aws_batch plugin
 			},
 		)
 	default:
-		logLinks, subTaskMetadata, err = GetTaskLinks(ctx, tCtx.TaskExecutionMetadata(), e.jobStore, pluginState)
+		logLinks, externalResources, err = GetTaskLinks(ctx, tCtx.TaskExecutionMetadata(), e.jobStore, pluginState)
 	}
 
 	if err != nil {
@@ -126,7 +126,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 	logger.Infof(ctx, "Exiting handle with phase [%v]", pluginState.State.CurrentPhase)
 
 	// Determine transition information from the state
-	phaseInfo, err := arrayCore.MapArrayStateToPluginPhase(ctx, pluginState.State, logLinks, subTaskMetadata)
+	phaseInfo, err := arrayCore.MapArrayStateToPluginPhase(ctx, pluginState.State, logLinks, externalResources)
 	if err != nil {
 		return core.UnknownTransition, err
 	}

--- a/go/tasks/plugins/array/awsbatch/task_links.go
+++ b/go/tasks/plugins/array/awsbatch/task_links.go
@@ -36,22 +36,14 @@ func GetJobTaskLog(jobSize int, accountID, region, queue, jobID string) *idlCore
 	}
 }
 
-type SubTaskDetails struct {
-	LogLinks   []*idlCore.TaskLog
-	SubTaskIDs []*string
-}
-
 func GetTaskLinks(ctx context.Context, taskMeta pluginCore.TaskExecutionMetadata, jobStore *JobStore, state *State) (
-	SubTaskDetails, error) {
+	[]*idlCore.TaskLog, []*core.SubTaskMetadata, error) {
 
 	logLinks := make([]*idlCore.TaskLog, 0, 4)
-	subTaskIDs := make([]*string, 0)
+	subTaskMetadata := make([]*core.SubTaskMetadata, 0)
 
 	if state.GetExternalJobID() == nil {
-		return SubTaskDetails{
-			LogLinks:   logLinks,
-			SubTaskIDs: subTaskIDs,
-		}, nil
+		return logLinks, subTaskMetadata, nil
 	}
 
 	// TODO: Add tasktemplate container config to job config
@@ -67,20 +59,14 @@ func GetTaskLinks(ctx context.Context, taskMeta pluginCore.TaskExecutionMetadata
 	})
 
 	if err != nil {
-		return SubTaskDetails{
-			LogLinks:   logLinks,
-			SubTaskIDs: subTaskIDs,
-		}, errors.Wrapf(errors2.DownstreamSystemError, err, "Failed to retrieve a job from job store.")
+		return logLinks, subTaskMetadata, errors.Wrapf(errors2.DownstreamSystemError, err, "Failed to retrieve a job from job store.")
 	}
 
 	if job == nil {
 		logger.Debugf(ctx, "Job [%v] not found in jobs store. It might have been evicted. If reasonable, bump the max "+
 			"size of the LRU cache.", *state.GetExternalJobID())
 
-		return SubTaskDetails{
-			LogLinks:   logLinks,
-			SubTaskIDs: subTaskIDs,
-		}, nil
+		return logLinks, subTaskMetadata, nil
 	}
 
 	detailedArrayStatus := state.GetArrayStatus().Detailed
@@ -90,19 +76,23 @@ func GetTaskLinks(ctx context.Context, taskMeta pluginCore.TaskExecutionMetadata
 		finalPhase := pluginCore.Phases[finalPhaseIdx]
 
 		// The caveat here is that we will mark all attempts with the final phase we are tracking in the state.
+		subTaskLogLinks := make([]*idlCore.TaskLog, 0)
 		for attemptIdx, attempt := range subJob.Attempts {
 			if len(attempt.LogStream) > 0 {
-				logLinks = append(logLinks, &idlCore.TaskLog{
+				subTaskLogLinks = append(subTaskLogLinks, &idlCore.TaskLog{
 					Name: fmt.Sprintf("AWS Batch #%v-%v (%v)", originalIndex, attemptIdx, finalPhase),
 					Uri:  fmt.Sprintf(LogStreamFormatter, jobStore.GetRegion(), attempt.LogStream),
 				})
 			}
 		}
-		subTaskIDs = append(subTaskIDs, &subJob.ID)
+
+		subTaskMetadata = append(subTaskMetadata, &core.SubTaskMetadata{
+			ChildIndex:    childIdx,
+			Logs:          subTaskLogLinks,
+			OriginalIndex: originalIndex,
+			SubTaskID:     &subJob.ID,
+		})
 	}
 
-	return SubTaskDetails{
-		LogLinks:   logLinks,
-		SubTaskIDs: subTaskIDs,
-	}, nil
+	return logLinks, subTaskMetadata, nil
 }

--- a/go/tasks/plugins/array/core/metadata.go
+++ b/go/tasks/plugins/array/core/metadata.go
@@ -9,10 +9,10 @@ import (
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 )
 
-// InitializeSubTaskMetadata constructs an ExternalResource array where each element describes the
+// InitializeExternalResources constructs an ExternalResource array where each element describes the
 // initial state of the subtask. This involves labeling all cached subtasks as successful with a
 // cache hit and initializing others to undefined state.
-func InitializeSubTaskMetadata(ctx context.Context, tCtx core.TaskExecutionContext, state *State,
+func InitializeExternalResources(ctx context.Context, tCtx core.TaskExecutionContext, state *State,
 	generateSubTaskID func(core.TaskExecutionContext, int) string) ([]*core.ExternalResource, error) {
 	externalResources := make([]*core.ExternalResource, state.GetOriginalArraySize())
 

--- a/go/tasks/plugins/array/core/metadata.go
+++ b/go/tasks/plugins/array/core/metadata.go
@@ -46,7 +46,7 @@ func InitializeExternalResources(ctx context.Context, tCtx core.TaskExecutionCon
 			phase = core.PhaseSuccess
 			cacheStatus = idlCore.CatalogCacheStatus_CACHE_HIT
 
-			// child index is computed as a pseudo-value to ensure non-overlaping subTaskIDs
+			// child index is computed as a pseudo-value to ensure non-overlapping subTaskIDs
 			childIndex = state.GetExecutionArraySize() + cachedSubTaskCount
 			cachedSubTaskCount++
 		}

--- a/go/tasks/plugins/array/core/metadata_test.go
+++ b/go/tasks/plugins/array/core/metadata_test.go
@@ -1,0 +1,70 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
+
+	"github.com/flyteorg/flytestdlib/bitarray"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitializeExternalResources(t *testing.T) {
+	ctx := context.TODO()
+	subTaskCount := 10
+	cachedCount := 4
+
+	indexesToCache := InvertBitSet(bitarray.NewBitSet(uint(subTaskCount)), uint(subTaskCount))
+	for i := 0; i < cachedCount; i++ {
+		indexesToCache.Clear(uint(i))
+	}
+
+	tr := &mocks.TaskReader{}
+	tr.OnRead(ctx).Return(&idlCore.TaskTemplate{
+		Metadata: &idlCore.TaskMetadata{
+			Discoverable: true,
+		},
+	}, nil)
+
+	tID := &mocks.TaskExecutionID{}
+	tID.OnGetGeneratedName().Return("notfound")
+
+	tMeta := &mocks.TaskExecutionMetadata{}
+	tMeta.OnGetTaskExecutionID().Return(tID)
+
+	tCtx := &mocks.TaskExecutionContext{}
+	tCtx.OnTaskReader().Return(tr)
+	tCtx.OnTaskExecutionMetadata().Return(tMeta)
+
+	state := State{
+		OriginalArraySize:  int64(subTaskCount),
+		ExecutionArraySize: subTaskCount - cachedCount,
+		IndexesToCache:     indexesToCache,
+	}
+
+	externalResources, err := InitializeExternalResources(ctx, tCtx, &state,
+		func(_ core.TaskExecutionContext, i int) string {
+			return ""
+		},
+	)
+
+	assert.Nil(t, err)
+	assert.Equal(t, subTaskCount, len(externalResources))
+	for i, externalResource := range externalResources {
+		assert.Equal(t, uint32(i), externalResource.Index)
+		assert.Equal(t, 0, len(externalResource.Logs))
+		assert.Equal(t, uint32(0), externalResource.RetryAttempt)
+		if i < cachedCount {
+			assert.Equal(t, core.PhaseSuccess, externalResource.Phase)
+			assert.Equal(t, idlCore.CatalogCacheStatus_CACHE_HIT, externalResource.CacheStatus)
+		} else {
+			assert.Equal(t, core.PhaseUndefined, externalResource.Phase)
+			assert.Equal(t, idlCore.CatalogCacheStatus_CACHE_MISS, externalResource.CacheStatus)
+		}
+	}
+}

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -175,7 +175,7 @@ func GetPhaseVersionOffset(currentPhase Phase, length int64) uint32 {
 // Info fields will always be nil, because we're going to send log links individually. This simplifies our state
 // handling as we don't have to keep an ever growing list of log links (our batch jobs can be 5000 sub-tasks, keeping
 // all the log links takes up a lot of space).
-func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idlCore.TaskLog, externalResources []*core.ExternalResource) (core.PhaseInfo, error) {
+func MapArrayStateToPluginPhase(ctx context.Context, state *State, logLinks []*idlCore.TaskLog, externalResources []*core.ExternalResource) (core.PhaseInfo, error) {
 	phaseInfo := core.PhaseInfoUndefined
 	t := time.Now()
 
@@ -222,6 +222,7 @@ func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idl
 			length = state.GetOriginalArraySize()
 		}
 
+		// TODO hamersaw - need to make sure version increments when a subtask phase changes
 		version := GetPhaseVersionOffset(p, length) + version
 		phaseInfo = core.PhaseInfoRunning(version, nowTaskInfo)
 
@@ -245,6 +246,8 @@ func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idl
 		return phaseInfo, fmt.Errorf("failed to map custom state phase to core phase. State Phase [%v]", p)
 	}
 
+	p, _ := state.GetPhase()
+	logger.Infof(ctx, "HAMERSAW - %s %s %d", p, phaseInfo.Phase(), phaseInfo.Version())
 	return phaseInfo, nil
 }
 

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -38,6 +38,12 @@ const (
 	PhasePermanentFailure
 )
 
+type SubTaskMetadata struct {
+	childIndex int
+	logs       []*idlCore.TaskLog
+	subTaskID  *string
+}
+
 type State struct {
 	CurrentPhase         Phase                   `json:"phase"`
 	PhaseVersion         uint32                  `json:"phaseVersion"`
@@ -175,17 +181,18 @@ func GetPhaseVersionOffset(currentPhase Phase, length int64) uint32 {
 // Info fields will always be nil, because we're going to send log links individually. This simplifies our state
 // handling as we don't have to keep an ever growing list of log links (our batch jobs can be 5000 sub-tasks, keeping
 // all the log links takes up a lot of space).
-func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idlCore.TaskLog, subTaskIDs []*string) (core.PhaseInfo, error) {
+func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idlCore.TaskLog, subTaskMetadata []SubTaskMetadata) (core.PhaseInfo, error) {
 	phaseInfo := core.PhaseInfoUndefined
 	t := time.Now()
 
 	nowTaskInfo := &core.TaskInfo{
 		OccurredAt:        &t,
 		Logs:              logLinks,
-		ExternalResources: make([]*core.ExternalResource, len(subTaskIDs)),
+		ExternalResources: make([]*core.ExternalResource, len(subTaskMetadata)),
 	}
 
-	for childIndex, subTaskID := range subTaskIDs {
+	// TODO hamersaw - complete
+	/*for childIndex, subTaskID := range subTaskIDs {
 		originalIndex := CalculateOriginalIndex(childIndex, state.GetIndexesToCache())
 
 		nowTaskInfo.ExternalResources[childIndex] = &core.ExternalResource{
@@ -194,7 +201,7 @@ func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idl
 			RetryAttempt: uint32(state.RetryAttempts.GetItem(childIndex)),
 			Phase:        core.Phases[state.ArrayStatus.Detailed.GetItem(childIndex)],
 		}
-	}
+	}*/
 
 	switch p, version := state.GetPhase(); p {
 	case PhaseStart:

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -175,7 +175,7 @@ func GetPhaseVersionOffset(currentPhase Phase, length int64) uint32 {
 // Info fields will always be nil, because we're going to send log links individually. This simplifies our state
 // handling as we don't have to keep an ever growing list of log links (our batch jobs can be 5000 sub-tasks, keeping
 // all the log links takes up a lot of space).
-func MapArrayStateToPluginPhase(ctx context.Context, state *State, logLinks []*idlCore.TaskLog, externalResources []*core.ExternalResource) (core.PhaseInfo, error) {
+func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idlCore.TaskLog, externalResources []*core.ExternalResource) (core.PhaseInfo, error) {
 	phaseInfo := core.PhaseInfoUndefined
 	t := time.Now()
 
@@ -222,7 +222,6 @@ func MapArrayStateToPluginPhase(ctx context.Context, state *State, logLinks []*i
 			length = state.GetOriginalArraySize()
 		}
 
-		// TODO hamersaw - need to make sure version increments when a subtask phase changes
 		version := GetPhaseVersionOffset(p, length) + version
 		phaseInfo = core.PhaseInfoRunning(version, nowTaskInfo)
 
@@ -246,8 +245,6 @@ func MapArrayStateToPluginPhase(ctx context.Context, state *State, logLinks []*i
 		return phaseInfo, fmt.Errorf("failed to map custom state phase to core phase. State Phase [%v]", p)
 	}
 
-	p, _ := state.GetPhase()
-	logger.Infof(ctx, "HAMERSAW - %s %s %d", p, phaseInfo.Phase(), phaseInfo.Version())
 	return phaseInfo, nil
 }
 

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -186,13 +186,13 @@ func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idl
 	}
 
 	for i, subTask := range subTaskMetadata {
-		//var cacheStatus idlCore.CatalogCacheStatus
+		var cacheStatus idlCore.CatalogCacheStatus
 		phase := core.PhaseUndefined
 		retryAttempt := uint32(0)
 
 		if state.GetIndexesToCache().IsSet(uint(subTask.OriginalIndex)) {
 			// task has been cached
-			//cacheStatus = idlCore.CatalogCacheStatus_CACHE_HIT
+			cacheStatus = idlCore.CatalogCacheStatus_CACHE_HIT
 			phase = core.PhaseSuccess
 		} else {
 			if subTask.ChildIndex < 0 || subTask.ChildIndex >= state.GetExecutionArraySize() {
@@ -213,9 +213,9 @@ func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idl
 
 		nowTaskInfo.ExternalResources[i] = &core.ExternalResource{
 			ExternalID:   *subTask.SubTaskID,
-			//CacheStatus:  cacheStatus,
+			CacheStatus:  cacheStatus,
 			Index:        uint32(subTask.OriginalIndex),
-			//Logs:         subTask.Logs,
+			Logs:         subTask.Logs,
 			RetryAttempt: uint32(retryAttempt),
 			Phase:        phase,
 		}

--- a/go/tasks/plugins/array/core/subtask_metadata.go
+++ b/go/tasks/plugins/array/core/subtask_metadata.go
@@ -1,0 +1,45 @@
+package core
+
+import (
+	"context"
+
+	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
+
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+)
+
+type SubTaskMetadata struct {
+	ChildIndex    int
+	Logs          []*idlCore.TaskLog
+	OriginalIndex int
+	SubTaskID     *string
+}
+
+func InitializeSubTaskMetadata(ctx context.Context, tCtx core.TaskExecutionContext, state *State,
+	generateSubTaskID func(core.TaskExecutionContext, int) string) ([]*SubTaskMetadata, error) {
+
+	subTaskMetadata := make([]*SubTaskMetadata, state.GetOriginalArraySize())
+
+	executeSubTaskCount := 0
+	cachedSubTaskCount := 0
+	for i := 0; i < int(state.GetOriginalArraySize()); i++ {
+		var childIndex int
+		if state.IndexesToCache.IsSet(uint(i)) {
+			childIndex = executeSubTaskCount
+			executeSubTaskCount++
+		} else {
+			childIndex = state.GetExecutionArraySize() + cachedSubTaskCount
+			cachedSubTaskCount++
+		}
+
+		subTaskID := generateSubTaskID(tCtx, childIndex)
+		subTaskMetadata[i] = &SubTaskMetadata{
+			ChildIndex:    childIndex,
+			Logs:          nil,
+			OriginalIndex: i,
+			SubTaskID:     &subTaskID,
+		}
+	}
+
+	return subTaskMetadata, nil
+}

--- a/go/tasks/plugins/array/core/subtask_metadata.go
+++ b/go/tasks/plugins/array/core/subtask_metadata.go
@@ -5,41 +5,59 @@ import (
 
 	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 
+	"github.com/flyteorg/flyteplugins/go/tasks/errors"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 )
 
-type SubTaskMetadata struct {
-	ChildIndex    int
-	Logs          []*idlCore.TaskLog
-	OriginalIndex int
-	SubTaskID     *string
-}
-
 func InitializeSubTaskMetadata(ctx context.Context, tCtx core.TaskExecutionContext, state *State,
-	generateSubTaskID func(core.TaskExecutionContext, int) string) ([]*SubTaskMetadata, error) {
+	generateSubTaskID func(core.TaskExecutionContext, int) string) ([]*core.ExternalResource, error) {
+	externalResources := make([]*core.ExternalResource, state.GetOriginalArraySize())
 
-	subTaskMetadata := make([]*SubTaskMetadata, state.GetOriginalArraySize())
+	taskTemplate, err := tCtx.TaskReader().Read(ctx)
+	if err != nil {
+		return externalResources, err
+	} else if taskTemplate == nil {
+		return externalResources, errors.Errorf(errors.BadTaskSpecification, "Required value not set, taskTemplate is nil")
+	}
 
 	executeSubTaskCount := 0
 	cachedSubTaskCount := 0
 	for i := 0; i < int(state.GetOriginalArraySize()); i++ {
+		var cacheStatus idlCore.CatalogCacheStatus
 		var childIndex int
+		var phase core.Phase
+
 		if state.IndexesToCache.IsSet(uint(i)) {
+			// if not cached set to PhaseUndefined and set cacheStatus according to Discoverable
+			phase = core.PhaseUndefined
+			if taskTemplate.Metadata == nil || !taskTemplate.Metadata.Discoverable {
+				cacheStatus = idlCore.CatalogCacheStatus_CACHE_MISS
+			} else {
+				cacheStatus = idlCore.CatalogCacheStatus_CACHE_DISABLED
+			}
+
 			childIndex = executeSubTaskCount
 			executeSubTaskCount++
 		} else {
+			// if cached set to PhaseSuccess and mark as CACHE_HIT
+			phase = core.PhaseSuccess
+			cacheStatus = idlCore.CatalogCacheStatus_CACHE_HIT
+
+			// child index is computed as a pseudo-value to ensure non-overlaping subTaskIDs
 			childIndex = state.GetExecutionArraySize() + cachedSubTaskCount
 			cachedSubTaskCount++
 		}
 
 		subTaskID := generateSubTaskID(tCtx, childIndex)
-		subTaskMetadata[i] = &SubTaskMetadata{
-			ChildIndex:    childIndex,
-			Logs:          nil,
-			OriginalIndex: i,
-			SubTaskID:     &subTaskID,
+		externalResources[i] = &core.ExternalResource{
+			ExternalID:   subTaskID,
+			CacheStatus:  cacheStatus,
+			Index:        uint32(i),
+			Logs:         nil,
+			RetryAttempt: 0,
+			Phase:        phase,
 		}
 	}
 
-	return subTaskMetadata, nil
+	return externalResources, nil
 }

--- a/go/tasks/plugins/array/core/subtask_metadata.go
+++ b/go/tasks/plugins/array/core/subtask_metadata.go
@@ -9,6 +9,9 @@ import (
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 )
 
+// InitializeSubTaskMetadata constructs an ExternalResource array where each element describes the
+// initial state of the subtask. This involves labeling all cached subtasks as successful with a
+// cache hit and initializing others to undefined state.
 func InitializeSubTaskMetadata(ctx context.Context, tCtx core.TaskExecutionContext, state *State,
 	generateSubTaskID func(core.TaskExecutionContext, int) string) ([]*core.ExternalResource, error) {
 	externalResources := make([]*core.ExternalResource, state.GetOriginalArraySize())

--- a/go/tasks/plugins/array/core/subtask_metadata.go
+++ b/go/tasks/plugins/array/core/subtask_metadata.go
@@ -31,9 +31,9 @@ func InitializeSubTaskMetadata(ctx context.Context, tCtx core.TaskExecutionConte
 			// if not cached set to PhaseUndefined and set cacheStatus according to Discoverable
 			phase = core.PhaseUndefined
 			if taskTemplate.Metadata == nil || !taskTemplate.Metadata.Discoverable {
-				cacheStatus = idlCore.CatalogCacheStatus_CACHE_MISS
-			} else {
 				cacheStatus = idlCore.CatalogCacheStatus_CACHE_DISABLED
+			} else {
+				cacheStatus = idlCore.CatalogCacheStatus_CACHE_MISS
 			}
 
 			childIndex = executeSubTaskCount

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -87,15 +87,20 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 	switch p, _ := pluginState.GetPhase(); p {
 	case arrayCore.PhaseStart:
 		nextState, err = array.DetermineDiscoverability(ctx, tCtx, pluginState)
+		if err != nil {
+			return core.UnknownTransition, err
+		}
 
-	case arrayCore.PhasePreLaunch:
-		nextState = pluginState.SetPhase(arrayCore.PhaseLaunch, core.DefaultPhaseVersion).SetReason("Nothing to do in PreLaunch phase.")
 		subTaskMetadata, err = arrayCore.InitializeSubTaskMetadata(ctx, tCtx, pluginState,
 			func(tCtx core.TaskExecutionContext, childIndex int) string {
 				subTaskExecutionID := NewSubTaskExecutionID(tCtx.TaskExecutionMetadata().GetTaskExecutionID(), childIndex, 0)
 				return subTaskExecutionID.GetGeneratedName()
 			},
 		)
+
+	case arrayCore.PhasePreLaunch:
+		nextState = pluginState.SetPhase(arrayCore.PhaseLaunch, core.DefaultPhaseVersion).SetReason("Nothing to do in PreLaunch phase.")
+		err = nil
 
 	case arrayCore.PhaseWaitingForResources:
 		fallthrough

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -91,7 +91,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 			return core.UnknownTransition, err
 		}
 
-		externalResources, err = arrayCore.InitializeSubTaskMetadata(ctx, tCtx, pluginState,
+		externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, pluginState,
 			func(tCtx core.TaskExecutionContext, childIndex int) string {
 				subTaskExecutionID := NewSubTaskExecutionID(tCtx.TaskExecutionMetadata().GetTaskExecutionID(), childIndex, 0)
 				return subTaskExecutionID.GetGeneratedName()

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -84,7 +84,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 	var err error
 	var externalResources []*core.ExternalResource
 
-	switch p, _ := pluginState.GetPhase(); p {
+	switch p, version := pluginState.GetPhase(); p {
 	case arrayCore.PhaseStart:
 		nextState, err = array.DetermineDiscoverability(ctx, tCtx, pluginState)
 		if err != nil {
@@ -109,11 +109,10 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		// In order to maintain backwards compatibility with the state transitions
 		// in the aws batch plugin. Forward to PhaseCheckingSubTasksExecutions where the launching
 		// is actually occurring.
-		nextState = pluginState.SetPhase(arrayCore.PhaseCheckingSubTaskExecutions, core.DefaultPhaseVersion).SetReason("Nothing to do in Launch phase.")
+		nextState = pluginState.SetPhase(arrayCore.PhaseCheckingSubTaskExecutions, version).SetReason("Nothing to do in Launch phase.")
 		err = nil
 
 	case arrayCore.PhaseCheckingSubTaskExecutions:
-
 		nextState, externalResources, err = LaunchAndCheckSubTasksState(ctx, tCtx, e.kubeClient, pluginConfig,
 			tCtx.DataStore(), tCtx.OutputWriter().GetOutputPrefixPath(), tCtx.OutputWriter().GetRawOutputPrefix(), pluginState)
 

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -128,6 +128,8 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 	currentParallelism := 0
 	maxParallelism := int(arrayJob.Parallelism)
 
+	// TODO hamersaw - compute hash of detailed array (to determine any changes in arrayStatus)
+
 	for childIdx, existingPhaseIdx := range currentState.GetArrayStatus().Detailed.GetItems() {
 		existingPhase := core.Phases[existingPhaseIdx]
 		retryAttempt := currentState.RetryAttempts.GetItem(childIdx)
@@ -252,6 +254,8 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		newState = newState.SetReason(errorMsg)
 	}
 
+	// TODO hamersaw - check if new arraystatus has a changed state (if so - increment the phase version)
+	// does this handle the top-level phase changes?
 	if phase == arrayCore.PhaseCheckingSubTaskExecutions {
 		newPhaseVersion := uint32(0)
 

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -63,12 +63,12 @@ func deallocateResource(ctx context.Context, tCtx core.TaskExecutionContext, con
 // resources, retrying failed attempts, or declaring a permanent failure among others.
 func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionContext, kubeClient core.KubeClient,
 	config *Config, dataStore *storage.DataStore, outputPrefix, baseOutputDataSandbox storage.DataReference, currentState *arrayCore.State) (
-	newState *arrayCore.State, subTaskMetadata []*arrayCore.SubTaskMetadata, err error) {
+	newState *arrayCore.State, externalResources []*core.ExternalResource, err error) {
 	if int64(currentState.GetExecutionArraySize()) > config.MaxArrayJobSize {
 		ee := fmt.Errorf("array size > max allowed. Requested [%v]. Allowed [%v]", currentState.GetExecutionArraySize(), config.MaxArrayJobSize)
 		logger.Info(ctx, ee)
 		currentState = currentState.SetPhase(arrayCore.PhasePermanentFailure, 0).SetReason(ee.Error())
-		return currentState, subTaskMetadata, nil
+		return currentState, externalResources, nil
 	}
 
 	newState = currentState
@@ -77,7 +77,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		Summary:  arraystatus.ArraySummary{},
 		Detailed: arrayCore.NewPhasesCompactArray(uint(currentState.GetExecutionArraySize())),
 	}
-	subTaskMetadata = make([]*arrayCore.SubTaskMetadata, 0, len(currentState.GetArrayStatus().Detailed.GetItems()))
+	externalResources = make([]*core.ExternalResource, 0, len(currentState.GetArrayStatus().Detailed.GetItems()))
 
 	// If we have arrived at this state for the first time then currentState has not been
 	// initialized with number of sub tasks.
@@ -94,7 +94,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		retryAttemptsArray, err := bitarray.NewCompactArray(count, maxValue)
 		if err != nil {
 			logger.Errorf(context.Background(), "Failed to create attempts compact array with [count: %v, maxValue: %v]", count, maxValue)
-			return currentState, subTaskMetadata, nil
+			return currentState, externalResources, nil
 		}
 
 		// Initialize subtask retryAttempts to 0 so that, in tandem with the podName logic, we
@@ -109,20 +109,20 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 	// initialize log plugin
 	logPlugin, err := logs.InitializeLogPlugins(&config.LogConfig.Config)
 	if err != nil {
-		return currentState, subTaskMetadata, err
+		return currentState, externalResources, err
 	}
 
 	// identify max parallelism
 	taskTemplate, err := tCtx.TaskReader().Read(ctx)
 	if err != nil {
-		return currentState, subTaskMetadata, err
+		return currentState, externalResources, err
 	} else if taskTemplate == nil {
-		return currentState, subTaskMetadata, errors.Errorf(errors.BadTaskSpecification, "Required value not set, taskTemplate is nil")
+		return currentState, externalResources, errors.Errorf(errors.BadTaskSpecification, "Required value not set, taskTemplate is nil")
 	}
 
 	arrayJob, err := arrayCore.ToArrayJob(taskTemplate.GetCustom(), taskTemplate.TaskTypeVersion)
 	if err != nil {
-		return currentState, subTaskMetadata, err
+		return currentState, externalResources, err
 	}
 
 	currentParallelism := 0
@@ -154,7 +154,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 			if err != nil {
 				logger.Errorf(ctx, "Resource manager failed for TaskExecId [%s] token [%s]. error %s",
 					stCtx.TaskExecutionMetadata().GetTaskExecutionID().GetID(), podName, err)
-				return currentState, subTaskMetadata, err
+				return currentState, externalResources, err
 			}
 
 			logger.Infof(ctx, "Allocation result for [%s] is [%s]", podName, allocationStatus)
@@ -176,11 +176,41 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 			phaseInfo, perr = getSubtaskPhaseInfo(ctx, stCtx, config, kubeClient, logPlugin)
 		}
 
-		// validate and process phaseInfo and perr
 		if perr != nil {
-			return currentState, subTaskMetadata, perr
+			return currentState, externalResources, perr
 		}
 
+		// process subtask phase
+		actualPhase := phaseInfo.Phase()
+		if actualPhase.IsSuccess() {
+			actualPhase, err = array.CheckTaskOutput(ctx, dataStore, outputPrefix, baseOutputDataSandbox, childIdx, originalIdx)
+			if err != nil {
+				return currentState, externalResources, err
+			}
+		}
+
+		if actualPhase == core.PhaseRetryableFailure && uint32(retryAttempt+1) >= stCtx.TaskExecutionMetadata().GetMaxAttempts() {
+			// If we see a retryable failure we must check if the number of retries exceeds the maximum
+			// attempts. If so, transition to a permanent failure so that is not attempted again.
+			actualPhase = core.PhasePermanentFailure
+		}
+		newArrayStatus.Detailed.SetItem(childIdx, bitarray.Item(actualPhase))
+
+		if actualPhase.IsTerminal() {
+			err = deallocateResource(ctx, stCtx, config, podName)
+			if err != nil {
+				logger.Errorf(ctx, "Error releasing allocation token [%s] in Finalize [%s]", podName, err)
+				return currentState, externalResources, err
+			}
+
+			err = finalizeSubtask(ctx, stCtx, config, kubeClient)
+			if err != nil {
+				logger.Errorf(ctx, "Error finalizing resource [%s] in Finalize [%s]", podName, err)
+				return currentState, externalResources, err
+			}
+		}
+
+		// process phaseInfo
 		if phaseInfo.Err() != nil {
 			messageCollector.Collect(childIdx, phaseInfo.Err().String())
 		}
@@ -190,43 +220,13 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 			logLinks = phaseInfo.Info().Logs
 		}
 
-		subTaskMetadata = append(subTaskMetadata, &arrayCore.SubTaskMetadata{
-			ChildIndex:    childIdx,
-			Logs:          logLinks,
-			OriginalIndex: originalIdx,
-			SubTaskID:     &podName,
+		externalResources = append(externalResources, &core.ExternalResource{
+			ExternalID:   podName,
+			Index:        uint32(originalIdx),
+			Logs:         logLinks,
+			RetryAttempt: uint32(retryAttempt),
+			Phase:        actualPhase,
 		})
-
-		// process subtask phase
-		actualPhase := phaseInfo.Phase()
-		if actualPhase.IsSuccess() {
-			actualPhase, err = array.CheckTaskOutput(ctx, dataStore, outputPrefix, baseOutputDataSandbox, childIdx, originalIdx)
-			if err != nil {
-				return currentState, subTaskMetadata, err
-			}
-		}
-
-		if actualPhase == core.PhaseRetryableFailure && uint32(retryAttempt+1) >= stCtx.TaskExecutionMetadata().GetMaxAttempts() {
-			// If we see a retryable failure we must check if the number of retries exceeds the maximum
-			// attempts. If so, transition to a permanent failure so that is not attempted again.
-			newArrayStatus.Detailed.SetItem(childIdx, bitarray.Item(core.PhasePermanentFailure))
-		} else {
-			newArrayStatus.Detailed.SetItem(childIdx, bitarray.Item(actualPhase))
-		}
-
-		if actualPhase.IsTerminal() {
-			err = deallocateResource(ctx, stCtx, config, podName)
-			if err != nil {
-				logger.Errorf(ctx, "Error releasing allocation token [%s] in Finalize [%s]", podName, err)
-				return currentState, subTaskMetadata, err
-			}
-
-			err = finalizeSubtask(ctx, stCtx, config, kubeClient)
-			if err != nil {
-				logger.Errorf(ctx, "Error finalizing resource [%s] in Finalize [%s]", podName, err)
-				return currentState, subTaskMetadata, err
-			}
-		}
 
 		// validate parallelism
 		if !actualPhase.IsTerminal() || actualPhase == core.PhaseRetryableFailure {
@@ -265,7 +265,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		newState = newState.SetPhase(phase, core.DefaultPhaseVersion)
 	}
 
-	return newState, subTaskMetadata, nil
+	return newState, externalResources, nil
 }
 
 // TerminateSubTasks performs operations to gracefully terminate all subtasks. This may include

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -128,8 +128,6 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 	currentParallelism := 0
 	maxParallelism := int(arrayJob.Parallelism)
 
-	// TODO hamersaw - compute hash of detailed array (to determine any changes in arrayStatus)
-
 	for childIdx, existingPhaseIdx := range currentState.GetArrayStatus().Detailed.GetItems() {
 		existingPhase := core.Phases[existingPhaseIdx]
 		retryAttempt := currentState.RetryAttempts.GetItem(childIdx)
@@ -254,8 +252,6 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		newState = newState.SetReason(errorMsg)
 	}
 
-	// TODO hamersaw - check if new arraystatus has a changed state (if so - increment the phase version)
-	// does this handle the top-level phase changes?
 	if phase == arrayCore.PhaseCheckingSubTaskExecutions {
 		newPhaseVersion := uint32(0)
 

--- a/go/tasks/plugins/array/k8s/management_test.go
+++ b/go/tasks/plugins/array/k8s/management_test.go
@@ -175,7 +175,7 @@ func TestCheckSubTasksState(t *testing.T) {
 		}
 
 		// execute
-		newState, _, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
+		newState, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
 
 		// validate results
 		assert.Nil(t, err)
@@ -212,7 +212,7 @@ func TestCheckSubTasksState(t *testing.T) {
 			}
 
 			// execute
-			newState, _, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
+			newState, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
 
 			// validate results
 			assert.Nil(t, err)
@@ -254,7 +254,7 @@ func TestCheckSubTasksState(t *testing.T) {
 		}
 
 		// execute
-		newState, _, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
+		newState, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
 
 		// validate results
 		assert.Nil(t, err)
@@ -272,7 +272,7 @@ func TestCheckSubTasksState(t *testing.T) {
 		ntCtx := getMockTaskExecutionContext(ctx, 0)
 		ntCtx.OnResourceManager().Return(&nresourceManager)
 
-		lastState, _, _, err := LaunchAndCheckSubTasksState(ctx, ntCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", newState)
+		lastState, _, err := LaunchAndCheckSubTasksState(ctx, ntCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", newState)
 		assert.Nil(t, err)
 		np, _ := lastState.GetPhase()
 		assert.Equal(t, arrayCore.PhaseCheckingSubTaskExecutions.String(), np.String())
@@ -315,7 +315,7 @@ func TestCheckSubTasksState(t *testing.T) {
 		}
 
 		// execute
-		newState, _, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
+		newState, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
 
 		// validate results
 		assert.Nil(t, err)
@@ -380,7 +380,7 @@ func TestCheckSubTasksState(t *testing.T) {
 		}
 
 		// execute
-		newState, logLinks, subTaskIDs, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
+		newState, externalResources, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
 
 		// validate results
 		assert.Nil(t, err)
@@ -390,18 +390,17 @@ func TestCheckSubTasksState(t *testing.T) {
 		resourceManager.AssertNumberOfCalls(t, "AllocateResource", 0)
 		resourceManager.AssertNumberOfCalls(t, "ReleaseResource", 0)
 
-		assert.NotEmpty(t, logLinks)
-		assert.Equal(t, subtaskCount*2, len(logLinks))
-		for i := 0; i < subtaskCount*2; i = i + 2 {
-			assert.Equal(t, fmt.Sprintf("Kubernetes Logs #0-%d (PhaseRunning)", i/2), logLinks[i].Name)
-			assert.Equal(t, fmt.Sprintf("k8s/log/a-n-b/notfound-%d/pod?namespace=a-n-b", i/2), logLinks[i].Uri)
-
-			assert.Equal(t, fmt.Sprintf("Cloudwatch Logs #0-%d (PhaseRunning)", i/2), logLinks[i+1].Name)
-			assert.Equal(t, fmt.Sprintf("https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=/kubernetes/flyte;prefix=var.log.containers.notfound-%d;streamFilter=typeLogStreamPrefix", i/2), logLinks[i+1].Uri)
-		}
-
+		assert.Equal(t, subtaskCount, len(externalResources))
 		for i := 0; i < subtaskCount; i++ {
-			assert.Equal(t, fmt.Sprintf("notfound-%d", i), *subTaskIDs[i])
+			externalResource := externalResources[i]
+			assert.Equal(t, fmt.Sprintf("notfound-%d", i), externalResource.ExternalID)
+
+			logLinks := externalResource.Logs
+			assert.Equal(t, 2, len(logLinks))
+			assert.Equal(t, fmt.Sprintf("Kubernetes Logs #0-%d (PhaseRunning)", i), logLinks[0].Name)
+			assert.Equal(t, fmt.Sprintf("k8s/log/a-n-b/notfound-%d/pod?namespace=a-n-b", i), logLinks[0].Uri)
+			assert.Equal(t, fmt.Sprintf("Cloudwatch Logs #0-%d (PhaseRunning)", i), logLinks[1].Name)
+			assert.Equal(t, fmt.Sprintf("https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=/kubernetes/flyte;prefix=var.log.containers.notfound-%d;streamFilter=typeLogStreamPrefix", i), logLinks[1].Uri)
 		}
 	})
 
@@ -438,7 +437,7 @@ func TestCheckSubTasksState(t *testing.T) {
 		}
 
 		// execute
-		newState, _, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
+		newState, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
 
 		// validate results
 		assert.Nil(t, err)
@@ -487,7 +486,7 @@ func TestCheckSubTasksState(t *testing.T) {
 		}
 
 		// execute
-		newState, _, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
+		newState, _, err := LaunchAndCheckSubTasksState(ctx, tCtx, &kubeClient, &config, nil, "/prefix/", "/prefix-sand/", currentState)
 
 		// validate results
 		assert.Nil(t, err)

--- a/go/tasks/plugins/array/k8s/management_test.go
+++ b/go/tasks/plugins/array/k8s/management_test.go
@@ -397,9 +397,9 @@ func TestCheckSubTasksState(t *testing.T) {
 
 			logLinks := externalResource.Logs
 			assert.Equal(t, 2, len(logLinks))
-			assert.Equal(t, fmt.Sprintf("Kubernetes Logs #0-%d (PhaseRunning)", i), logLinks[0].Name)
+			assert.Equal(t, fmt.Sprintf("Kubernetes Logs #0-%d", i), logLinks[0].Name)
 			assert.Equal(t, fmt.Sprintf("k8s/log/a-n-b/notfound-%d/pod?namespace=a-n-b", i), logLinks[0].Uri)
-			assert.Equal(t, fmt.Sprintf("Cloudwatch Logs #0-%d (PhaseRunning)", i), logLinks[1].Name)
+			assert.Equal(t, fmt.Sprintf("Cloudwatch Logs #0-%d", i), logLinks[1].Name)
 			assert.Equal(t, fmt.Sprintf("https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logStream:group=/kubernetes/flyte;prefix=var.log.containers.notfound-%d;streamFilter=typeLogStreamPrefix", i), logLinks[1].Uri)
 		}
 	})

--- a/go/tasks/plugins/array/k8s/subtask.go
+++ b/go/tasks/plugins/array/k8s/subtask.go
@@ -309,13 +309,6 @@ func getSubtaskPhaseInfo(ctx context.Context, stCtx SubTaskExecutionContext, cfg
 		return pluginsCore.PhaseInfoUndefined, err
 	}
 
-	if phaseInfo.Info() != nil {
-		// Append sub-job status in Log Name for viz.
-		for _, log := range phaseInfo.Info().Logs {
-			log.Name += fmt.Sprintf(" (%s)", phaseInfo.Phase().String())
-		}
-	}
-
 	return phaseInfo, err
 }
 

--- a/go/tasks/plugins/array/k8s/subtask_exec_context.go
+++ b/go/tasks/plugins/array/k8s/subtask_exec_context.go
@@ -40,7 +40,7 @@ func (s SubTaskExecutionContext) TaskReader() pluginsCore.TaskReader {
 	return s.subtaskReader
 }
 
-// newSubtaskExecutionContext constructs a SubTaskExecutionContext using the provided parameters
+// NewSubtaskExecutionContext constructs a SubTaskExecutionContext using the provided parameters
 func NewSubTaskExecutionContext(tCtx pluginsCore.TaskExecutionContext, taskTemplate *core.TaskTemplate,
 	executionIndex, originalIndex int, retryAttempt uint64) SubTaskExecutionContext {
 
@@ -115,7 +115,7 @@ func (s SubTaskExecutionID) GetLogSuffix() string {
 	return fmt.Sprintf(" #%d-%d-%d", s.taskRetryAttempt, s.executionIndex, s.subtaskRetryAttempt)
 }
 
-// TODO hamersaw - document
+// NewSubtaskExecutionID constructs a SubTaskExecutionID using the provided parameters
 func NewSubTaskExecutionID(taskExecutionID pluginsCore.TaskExecutionID, executionIndex int, retryAttempt uint64) SubTaskExecutionID {
 	return SubTaskExecutionID{
 		taskExecutionID,
@@ -137,7 +137,7 @@ func (s SubTaskExecutionMetadata) GetTaskExecutionID() pluginsCore.TaskExecution
 	return s.subtaskExecutionID
 }
 
-// TODO hamersaw - document
+// NewSubtaskExecutionMetadata constructs a SubTaskExecutionMetadata using the provided parameters
 func NewSubTaskExecutionMetadata(taskExecutionMetadata pluginsCore.TaskExecutionMetadata, executionIndex int, retryAttempt uint64) SubTaskExecutionMetadata {
 	subTaskExecutionID := NewSubTaskExecutionID(taskExecutionMetadata.GetTaskExecutionID(), executionIndex, retryAttempt)
 	return SubTaskExecutionMetadata{

--- a/go/tasks/plugins/array/k8s/subtask_exec_context_test.go
+++ b/go/tasks/plugins/array/k8s/subtask_exec_context_test.go
@@ -21,9 +21,9 @@ func TestSubTaskExecutionContext(t *testing.T) {
 	originalIndex := 5
 	retryAttempt := uint64(1)
 
-	stCtx := newSubTaskExecutionContext(tCtx, taskTemplate, executionIndex, originalIndex, retryAttempt)
+	stCtx := NewSubTaskExecutionContext(tCtx, taskTemplate, executionIndex, originalIndex, retryAttempt)
 
-	assert.Equal(t, stCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), fmt.Sprintf("notfound-%d-%d", executionIndex, retryAttempt))
+	assert.Equal(t, fmt.Sprintf("notfound-%d-%d", executionIndex, retryAttempt), stCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName())
 
 	subtaskTemplate, err := stCtx.TaskReader().Read(ctx)
 	assert.Nil(t, err)


### PR DESCRIPTION
# TL;DR
Currently the map task only sends ExternalResources for subtasks which are currently being executed. This means FlyteAdmin, and consequently the UI, doesn't know which tasks have been cached, or how many tasks (or which ones) have not yet been started. This PR send a comprehensive list of subtasks (including marking cached as success) when a map task starts, this allows comprehensive tracking on map task subtask executions.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2288

## Follow-up issue
_NA_
