### PR TITLE
Supporting interruptible for map tasks

### DIFF
--- a/go/tasks/pluginmachinery/core/exec_metadata.go
+++ b/go/tasks/pluginmachinery/core/exec_metadata.go
@@ -44,4 +44,5 @@ type TaskExecutionMetadata interface {
 	GetSecurityContext() core.SecurityContext
 	IsInterruptible() bool
 	GetPlatformResources() *v1.ResourceRequirements
+	GetInterruptibleFailureThreshold() uint32
 }

--- a/go/tasks/pluginmachinery/core/mocks/task_execution_metadata.go
+++ b/go/tasks/pluginmachinery/core/mocks/task_execution_metadata.go
@@ -54,6 +54,38 @@ func (_m *TaskExecutionMetadata) GetAnnotations() map[string]string {
 	return r0
 }
 
+type TaskExecutionMetadata_GetInterruptibleFailureThreshold struct {
+	*mock.Call
+}
+
+func (_m TaskExecutionMetadata_GetInterruptibleFailureThreshold) Return(_a0 uint32) *TaskExecutionMetadata_GetInterruptibleFailureThreshold {
+	return &TaskExecutionMetadata_GetInterruptibleFailureThreshold{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *TaskExecutionMetadata) OnGetInterruptibleFailureThreshold() *TaskExecutionMetadata_GetInterruptibleFailureThreshold {
+	c := _m.On("GetInterruptibleFailureThreshold")
+	return &TaskExecutionMetadata_GetInterruptibleFailureThreshold{Call: c}
+}
+
+func (_m *TaskExecutionMetadata) OnGetInterruptibleFailureThresholdMatch(matchers ...interface{}) *TaskExecutionMetadata_GetInterruptibleFailureThreshold {
+	c := _m.On("GetInterruptibleFailureThreshold", matchers...)
+	return &TaskExecutionMetadata_GetInterruptibleFailureThreshold{Call: c}
+}
+
+// GetInterruptibleFailureThreshold provides a mock function with given fields:
+func (_m *TaskExecutionMetadata) GetInterruptibleFailureThreshold() uint32 {
+	ret := _m.Called()
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	return r0
+}
+
 type TaskExecutionMetadata_GetK8sServiceAccount struct {
 	*mock.Call
 }

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -109,7 +109,6 @@ func TestPodSetup(t *testing.T) {
 	t.Run("ApplyInterruptibleNodeAffinity", TestApplyInterruptibleNodeAffinity)
 	t.Run("UpdatePod", updatePod)
 	t.Run("ToK8sPodInterruptible", toK8sPodInterruptible)
-	t.Run("toK8sPodInterruptibleFalse", toK8sPodInterruptibleFalse)
 }
 
 func TestApplyInterruptibleNodeAffinity(t *testing.T) {
@@ -333,43 +332,6 @@ func toK8sPodInterruptible(t *testing.T) {
 	assert.Equal(t, 1, len(p.NodeSelector))
 	assert.Equal(t, "true", p.NodeSelector["x/interruptible"])
 	assert.EqualValues(
-		t,
-		[]v1.NodeSelectorTerm{
-			v1.NodeSelectorTerm{
-				MatchExpressions: []v1.NodeSelectorRequirement{
-					v1.NodeSelectorRequirement{
-						Key:      "x/interruptible",
-						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{"true"},
-					},
-				},
-			},
-		},
-		p.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-	)
-}
-
-func toK8sPodInterruptibleFalse(t *testing.T) {
-	ctx := context.TODO()
-
-	x := dummyExecContext(&v1.ResourceRequirements{
-		Limits: v1.ResourceList{
-			v1.ResourceCPU:     resource.MustParse("1024m"),
-			v1.ResourceStorage: resource.MustParse("100M"),
-			ResourceNvidiaGPU:  resource.MustParse("1"),
-		},
-		Requests: v1.ResourceList{
-			v1.ResourceCPU:     resource.MustParse("1024m"),
-			v1.ResourceStorage: resource.MustParse("100M"),
-		},
-	})
-
-	p, err := ToK8sPodSpecWithInterruptible(ctx, x, true)
-	assert.NoError(t, err)
-	assert.Len(t, p.Tolerations, 1)
-	assert.Equal(t, 0, len(p.NodeSelector))
-	assert.Equal(t, "", p.NodeSelector["x/interruptible"])
-	assert.NotEqualValues(
 		t,
 		[]v1.NodeSelectorTerm{
 			v1.NodeSelectorTerm{

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -53,6 +53,9 @@ type State struct {
 
 	// Tracks the number of subtask retries using the execution index
 	RetryAttempts bitarray.CompactArray `json:"retryAttempts"`
+
+	// Tracks the number of system failures for each subtask using the execution index
+	SystemFailures bitarray.CompactArray `json:"systemFailures"`
 }
 
 func (s State) GetReason() string {

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -107,7 +107,9 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		currentState.RetryAttempts = retryAttemptsArray
 	}
 
-	// TODO hamersaw - document
+	// If the current State is newly minted then we must initialize SystemFailures to track how many
+	// times the subtask failed due to system issues, this is necessary to correctly evaluate
+	// interruptible subtasks.
 	if len(currentState.SystemFailures.GetItems()) == 0 {
 		count := uint(currentState.GetExecutionArraySize())
 		maxValue := bitarray.Item(tCtx.TaskExecutionMetadata().GetInterruptibleFailureThreshold())

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -308,9 +308,9 @@ func TerminateSubTasks(ctx context.Context, tCtx core.TaskExecutionContext, kube
 	for childIdx, existingPhaseIdx := range currentState.GetArrayStatus().Detailed.GetItems() {
 		existingPhase := core.Phases[existingPhaseIdx]
 		retryAttempt := uint64(0)
-		if childIdx >= len(currentState.RetryAttempts.GetItems()) {
+		if childIdx < len(currentState.RetryAttempts.GetItems()) {
 			// we can use RetryAttempts if it has been initialized, otherwise stay with default 0
-			currentState.RetryAttempts.GetItem(childIdx)
+			retryAttempt = currentState.RetryAttempts.GetItem(childIdx)
 		}
 
 		// return immediately if subtask has completed or not yet started

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -94,8 +94,8 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 
 		retryAttemptsArray, err := bitarray.NewCompactArray(count, maxValue)
 		if err != nil {
-			logger.Errorf(context.Background(), "Failed to create attempts compact array with [count: %v, maxValue: %v]", count, maxValue)
-			return currentState, logLinks, subTaskIDs, nil
+			logger.Errorf(ctx, "Failed to create attempts compact array with [count: %v, maxValue: %v]", count, maxValue)
+			return currentState, logLinks, subTaskIDs, err
 		}
 
 		// Initialize subtask retryAttempts to 0 so that, in tandem with the podName logic, we
@@ -116,8 +116,8 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 
 		systemFailuresArray, err := bitarray.NewCompactArray(count, maxValue)
 		if err != nil {
-			logger.Errorf(context.Background(), "Failed to create system failures array with [count: %v, maxValue: %v]", count, maxValue)
-			return currentState, logLinks, subTaskIDs, nil
+			logger.Errorf(ctx, "Failed to create system failures array with [count: %v, maxValue: %v]", count, maxValue)
+			return currentState, logLinks, subTaskIDs, err
 		}
 
 		for i := 0; i < currentState.GetExecutionArraySize(); i++ {

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -206,7 +206,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		}
 
 		if phaseInfo.Err() != nil && phaseInfo.Err().GetKind() == idlCore.ExecutionError_SYSTEM {
-			newState.SystemFailures.SetItem(childIdx, systemFailures + 1)
+			newState.SystemFailures.SetItem(childIdx, systemFailures+1)
 		} else {
 			newState.SystemFailures.SetItem(childIdx, systemFailures)
 		}

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -302,7 +302,7 @@ func TerminateSubTasks(ctx context.Context, tCtx core.TaskExecutionContext, kube
 	messageCollector := errorcollector.NewErrorMessageCollector()
 	for childIdx, existingPhaseIdx := range currentState.GetArrayStatus().Detailed.GetItems() {
 		existingPhase := core.Phases[existingPhaseIdx]
-		retryAttempt := 0
+		retryAttempt := uint64(0)
 		if childIdx >= len(currentState.RetryAttempts.GetItems()) {
 			// we can use RetryAttempts if it has been initialized, otherwise stay with default 0
 			currentState.RetryAttempts.GetItem(childIdx)

--- a/go/tasks/plugins/array/k8s/management_test.go
+++ b/go/tasks/plugins/array/k8s/management_test.go
@@ -91,6 +91,7 @@ func getMockTaskExecutionContext(ctx context.Context, parallelism int) *mocks.Ta
 	tMeta.OnGetAnnotations().Return(nil)
 	tMeta.OnGetOwnerReference().Return(metav1.OwnerReference{})
 	tMeta.OnGetPlatformResources().Return(&v1.ResourceRequirements{})
+	tMeta.OnGetInterruptibleFailureThreshold().Return(2)
 
 	ow := &mocks2.OutputWriter{}
 	ow.OnGetOutputPrefixPath().Return("/prefix/")

--- a/go/tasks/plugins/array/k8s/subtask_exec_context.go
+++ b/go/tasks/plugins/array/k8s/subtask_exec_context.go
@@ -141,7 +141,7 @@ func (s SubTaskExecutionMetadata) GetTaskExecutionID() pluginsCore.TaskExecution
 	return s.subtaskExecutionID
 }
 
-// TODO hamersaw - document
+// IsInterruptbile overrides the base NodeExecutionMetadata to return a subtask specific identifier
 func (s SubTaskExecutionMetadata) IsInterruptible() bool {
 	return s.interruptible
 }

--- a/go/tasks/plugins/array/k8s/subtask_exec_context_test.go
+++ b/go/tasks/plugins/array/k8s/subtask_exec_context_test.go
@@ -20,8 +20,9 @@ func TestSubTaskExecutionContext(t *testing.T) {
 	executionIndex := 0
 	originalIndex := 5
 	retryAttempt := uint64(1)
+	systemFailures := uint64(0)
 
-	stCtx := newSubTaskExecutionContext(tCtx, taskTemplate, executionIndex, originalIndex, retryAttempt)
+	stCtx := newSubTaskExecutionContext(tCtx, taskTemplate, executionIndex, originalIndex, retryAttempt, systemFailures)
 
 	assert.Equal(t, stCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), fmt.Sprintf("notfound-%d-%d", executionIndex, retryAttempt))
 

--- a/tests/end_to_end.go
+++ b/tests/end_to_end.go
@@ -176,6 +176,7 @@ func RunPluginEndToEndTest(t *testing.T, executor pluginCore.Plugin, template *i
 		Name:      execID,
 	})
 	tMeta.OnGetPlatformResources().Return(&v1.ResourceRequirements{})
+	tMeta.OnGetInterruptibleFailureThreshold().Return(2)
 
 	catClient := &catalogMocks.Client{}
 	catData := sync.Map{}


### PR DESCRIPTION
# TL;DR
Implemented IsInterruptible on SubTaskExecutionMetadata. This is set by tracking the number of system failures for each subtask and comparing to the InterruptibleFailureThreshold the same way this is performed in FlytePropeller for individual tasks.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

Fixing this by overriding the TaskExecutionContext IsInterruptible function means that we can essentially revert the [previous commit](https://github.com/flyteorg/flyteplugins/pull/214) adding an omitInterruptible flag which was used to disable support for interruptible nodes within map tasks.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/1533

## Follow-up issue
_NA_

