### PR TITLE
Use monotonically increasing phase version on map tasks

### DIFF
--- a/go/tasks/plugins/array/arraystatus/status.go
+++ b/go/tasks/plugins/array/arraystatus/status.go
@@ -23,6 +23,8 @@ type ArrayStatus struct {
 	Detailed bitarray.CompactArray `json:"details"`
 }
 
+// HashCode computes a hash of the phase indicies stored in the Detailed array to uniquely represent
+// a collection of subtask phases.
 func (a ArrayStatus) HashCode() (uint64, error) {
 	hash := fnv.New64()
 	bytes := make([]byte, 8)

--- a/go/tasks/plugins/array/arraystatus/status.go
+++ b/go/tasks/plugins/array/arraystatus/status.go
@@ -5,6 +5,9 @@
 package arraystatus
 
 import (
+	"encoding/binary"
+	"hash/fnv"
+
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flytestdlib/bitarray"
 )
@@ -18,6 +21,20 @@ type ArrayStatus struct {
 
 	// Status of every job in the array.
 	Detailed bitarray.CompactArray `json:"details"`
+}
+
+func (a ArrayStatus) HashCode() (uint64, error) {
+	hash := fnv.New64()
+	bytes := make([]byte, 8)
+	for _, phaseIndex := range a.Detailed.GetItems() {
+		binary.LittleEndian.PutUint64(bytes, phaseIndex)
+		_, err := hash.Write(bytes)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	return hash.Sum64(), nil
 }
 
 // This is a status object that is returned after we make Catalog calls to see if subtasks are Cached

--- a/go/tasks/plugins/array/arraystatus/status_test.go
+++ b/go/tasks/plugins/array/arraystatus/status_test.go
@@ -44,6 +44,7 @@ func TestArrayStatus_HashCode(t *testing.T) {
 			Detailed: actualDetailed,
 		}
 		actualHashCode, err := actual.HashCode()
+		assert.Nil(t, err)
 
 		assert.Equal(t, expectedHashCode, actualHashCode)
 	})
@@ -64,6 +65,7 @@ func TestArrayStatus_HashCode(t *testing.T) {
 			Detailed: actualDetailed,
 		}
 		actualHashCode, err := actual.HashCode()
+		assert.Nil(t, err)
 
 		assert.NotEqual(t, expectedHashCode, actualHashCode)
 	})
@@ -85,6 +87,7 @@ func TestArrayStatus_HashCode(t *testing.T) {
 			Detailed: actualDetailed,
 		}
 		actualHashCode, err := actual.HashCode()
+		assert.Nil(t, err)
 
 		assert.Equal(t, expectedHashCode, actualHashCode)
 	})

--- a/go/tasks/plugins/array/arraystatus/status_test.go
+++ b/go/tasks/plugins/array/arraystatus/status_test.go
@@ -8,8 +8,87 @@ import (
 	"testing"
 
 	types "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+
+	"github.com/flyteorg/flytestdlib/bitarray"
+
 	"github.com/stretchr/testify/assert"
 )
+
+func TestArrayStatus_HashCode(t *testing.T) {
+	size := uint(10)
+
+	t.Run("Empty Equal", func(t *testing.T) {
+		expected := ArrayStatus{}
+		expectedHashCode, err := expected.HashCode()
+		assert.Nil(t, err)
+
+		actual := ArrayStatus{}
+		actualHashCode, err := actual.HashCode()
+		assert.Nil(t, err)
+
+		assert.Equal(t, expectedHashCode, actualHashCode)
+	})
+
+	t.Run("Populated Equal", func(t *testing.T) {
+		expectedDetailed, err := bitarray.NewCompactArray(size, bitarray.Item(len(types.Phases)-1))
+		assert.Nil(t, err)
+		expected := ArrayStatus{
+			Detailed: expectedDetailed,
+		}
+		expectedHashCode, err := expected.HashCode()
+		assert.Nil(t, err)
+
+		actualDetailed, err := bitarray.NewCompactArray(size, bitarray.Item(len(types.Phases)-1))
+		assert.Nil(t, err)
+		actual := ArrayStatus{
+			Detailed: actualDetailed,
+		}
+		actualHashCode, err := actual.HashCode()
+
+		assert.Equal(t, expectedHashCode, actualHashCode)
+	})
+
+	t.Run("Updated Not Equal", func(t *testing.T) {
+		expectedDetailed, err := bitarray.NewCompactArray(size, bitarray.Item(len(types.Phases)-1))
+		assert.Nil(t, err)
+		expectedDetailed.SetItem(0, uint64(1))
+		expected := ArrayStatus{
+			Detailed: expectedDetailed,
+		}
+		expectedHashCode, err := expected.HashCode()
+		assert.Nil(t, err)
+
+		actualDetailed, err := bitarray.NewCompactArray(size, bitarray.Item(len(types.Phases)-1))
+		assert.Nil(t, err)
+		actual := ArrayStatus{
+			Detailed: actualDetailed,
+		}
+		actualHashCode, err := actual.HashCode()
+
+		assert.NotEqual(t, expectedHashCode, actualHashCode)
+	})
+
+	t.Run("Updated Equal", func(t *testing.T) {
+		expectedDetailed, err := bitarray.NewCompactArray(size, bitarray.Item(len(types.Phases)-1))
+		assert.Nil(t, err)
+		expectedDetailed.SetItem(0, uint64(1))
+		expected := ArrayStatus{
+			Detailed: expectedDetailed,
+		}
+		expectedHashCode, err := expected.HashCode()
+		assert.Nil(t, err)
+
+		actualDetailed, err := bitarray.NewCompactArray(size, bitarray.Item(len(types.Phases)-1))
+		actualDetailed.SetItem(0, uint64(1))
+		assert.Nil(t, err)
+		actual := ArrayStatus{
+			Detailed: actualDetailed,
+		}
+		actualHashCode, err := actual.HashCode()
+
+		assert.Equal(t, expectedHashCode, actualHashCode)
+	})
+}
 
 func TestArraySummary_MergeFrom(t *testing.T) {
 	t.Run("Update when not equal", func(t *testing.T) {

--- a/go/tasks/plugins/array/awsbatch/executor.go
+++ b/go/tasks/plugins/array/awsbatch/executor.go
@@ -69,14 +69,12 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		pluginState.State, err = array.DetermineDiscoverability(ctx, tCtx, pluginState.State)
 
 	case arrayCore.PhasePreLaunch:
-		// TODO hamersaw - need to fix phaseVersion
 		pluginState, err = EnsureJobDefinition(ctx, tCtx, pluginConfig, e.jobStore.Client, e.jobDefinitionCache, pluginState)
 
 	case arrayCore.PhaseWaitingForResources:
 		fallthrough
 
 	case arrayCore.PhaseLaunch:
-		// TODO hamersaw - need to fix phaseVersion
 		pluginState, err = LaunchSubTasks(ctx, tCtx, e.jobStore, pluginConfig, pluginState, e.metrics)
 
 	case arrayCore.PhaseCheckingSubTaskExecutions:

--- a/go/tasks/plugins/array/awsbatch/monitor.go
+++ b/go/tasks/plugins/array/awsbatch/monitor.go
@@ -63,6 +63,11 @@ func CheckSubTasksState(ctx context.Context, taskMeta core.TaskExecutionMetadata
 		Detailed: arrayCore.NewPhasesCompactArray(uint(currentState.GetExecutionArraySize())),
 	}
 
+	currentSubTaskPhaseHash, err := currentState.GetArrayStatus().HashCode()
+	if err != nil {
+		return currentState, err
+	}
+
 	queued := 0
 	for childIdx, subJob := range job.SubJobs {
 		actualPhase := subJob.Status.Phase
@@ -132,17 +137,20 @@ func CheckSubTasksState(ctx context.Context, taskMeta core.TaskExecutionMetadata
 		errorMsg := msg.Summary(cfg.MaxErrorStringLength)
 		parentState = parentState.SetReason(errorMsg)
 	}
+	_, version := currentState.GetPhase()
 	if phase == arrayCore.PhaseCheckingSubTaskExecutions {
-		// TODO hamersaw - use HashDetails to update version number
-		newPhaseVersion := uint32(0)
-		// For now, the only changes to PhaseVersion and PreviousSummary occur for running array jobs.
-		for phase, count := range parentState.GetArrayStatus().Summary {
-			newPhaseVersion += uint32(phase) * uint32(count)
+		newSubTaskPhaseHash, err := parentState.GetArrayStatus().HashCode()
+		if err != nil {
+			return currentState, err
 		}
 
-		parentState = parentState.SetPhase(phase, newPhaseVersion).SetReason("Task is still running.")
+		if newSubTaskPhaseHash != currentSubTaskPhaseHash {
+			version++
+		}
+
+		parentState = parentState.SetPhase(phase, version).SetReason("Task is still running")
 	} else {
-		parentState = parentState.SetPhase(phase, core.DefaultPhaseVersion)
+		parentState = parentState.SetPhase(phase, version)
 	}
 
 	p, v := parentState.GetPhase()

--- a/go/tasks/plugins/array/awsbatch/monitor.go
+++ b/go/tasks/plugins/array/awsbatch/monitor.go
@@ -133,6 +133,7 @@ func CheckSubTasksState(ctx context.Context, taskMeta core.TaskExecutionMetadata
 		parentState = parentState.SetReason(errorMsg)
 	}
 	if phase == arrayCore.PhaseCheckingSubTaskExecutions {
+		// TODO hamersaw - use HashDetails to update version number
 		newPhaseVersion := uint32(0)
 		// For now, the only changes to PhaseVersion and PreviousSummary occur for running array jobs.
 		for phase, count := range parentState.GetArrayStatus().Summary {

--- a/go/tasks/plugins/array/catalog.go
+++ b/go/tasks/plugins/array/catalog.go
@@ -193,7 +193,7 @@ func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContex
 	return state, nil
 }
 
-func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state *arrayCore.State, phaseOnSuccess arrayCore.Phase) (*arrayCore.State, error) {
+func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state *arrayCore.State, phaseOnSuccess arrayCore.Phase, versionOnSuccess uint32) (*arrayCore.State, error) {
 
 	// Check that the taskTemplate is valid
 	taskTemplate, err := tCtx.TaskReader().Read(ctx)
@@ -205,7 +205,7 @@ func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state
 
 	if tMeta := taskTemplate.Metadata; tMeta == nil || !tMeta.Discoverable {
 		logger.Debugf(ctx, "Task is not marked as discoverable. Moving to [%v] phase.", phaseOnSuccess)
-		return state.SetPhase(phaseOnSuccess, core.DefaultPhaseVersion).SetReason("Task is not discoverable."), nil
+		return state.SetPhase(phaseOnSuccess, versionOnSuccess).SetReason("Task is not discoverable."), nil
 	}
 
 	var inputReaders []io.InputReader
@@ -263,7 +263,7 @@ func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state
 	}
 
 	if len(catalogWriterItems) == 0 {
-		state.SetPhase(phaseOnSuccess, core.DefaultPhaseVersion).SetReason("No outputs need to be cached.")
+		state.SetPhase(phaseOnSuccess, versionOnSuccess).SetReason("No outputs need to be cached.")
 		return state, nil
 	}
 
@@ -273,7 +273,7 @@ func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state
 	}
 
 	if allWritten {
-		state.SetPhase(phaseOnSuccess, core.DefaultPhaseVersion).SetReason("Finished writing catalog cache.")
+		state.SetPhase(phaseOnSuccess, versionOnSuccess).SetReason("Finished writing catalog cache.")
 	}
 
 	return state, nil

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -219,8 +219,8 @@ func MapArrayStateToPluginPhase(ctx context.Context, state *State, logLinks []*i
 	case PhaseWriteToDiscovery:
 		// The state version is only incremented in PhaseCheckingSubTaskExecutions when subtask
 		// phases are updated. Therefore by adding the phase to the state version we ensure that
-		// all state changes will have a different phase version and are captured in task events.
-
+		// (1) all phase changes will have a new phase version and (2) all subtask phase updates
+		// result in monotonically increasing phase version.
 		phaseInfo = core.PhaseInfoRunning(version + uint32(p), nowTaskInfo)
 
 	case PhaseSuccess:

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -170,7 +170,7 @@ func ToArrayJob(structObj *structpb.Struct, taskTypeVersion int32) (*idlPlugins.
 // Info fields will always be nil, because we're going to send log links individually. This simplifies our state
 // handling as we don't have to keep an ever growing list of log links (our batch jobs can be 5000 sub-tasks, keeping
 // all the log links takes up a lot of space).
-func MapArrayStateToPluginPhase(ctx context.Context, state *State, logLinks []*idlCore.TaskLog, subTaskIDs []*string) (core.PhaseInfo, error) {
+func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idlCore.TaskLog, subTaskIDs []*string) (core.PhaseInfo, error) {
 	phaseInfo := core.PhaseInfoUndefined
 	t := time.Now()
 
@@ -243,8 +243,6 @@ func MapArrayStateToPluginPhase(ctx context.Context, state *State, logLinks []*i
 		return phaseInfo, fmt.Errorf("failed to map custom state phase to core phase. State Phase [%v]", p)
 	}
 
-	p, version := state.GetPhase()
-	logger.Infof(ctx, "HAMERSAW - %s %d %s %d", p, version, phaseInfo.Phase(), phaseInfo.Version())
 	return phaseInfo, nil
 }
 

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -221,7 +221,7 @@ func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idl
 		// phases are updated. Therefore by adding the phase to the state version we ensure that
 		// (1) all phase changes will have a new phase version and (2) all subtask phase updates
 		// result in monotonically increasing phase version.
-		phaseInfo = core.PhaseInfoRunning(version + uint32(p), nowTaskInfo)
+		phaseInfo = core.PhaseInfoRunning(version+uint32(p), nowTaskInfo)
 
 	case PhaseSuccess:
 		phaseInfo = core.PhaseInfoSuccess(nowTaskInfo)

--- a/go/tasks/plugins/array/core/state_test.go
+++ b/go/tasks/plugins/array/core/state_test.go
@@ -15,14 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetPhaseVersionOffset(t *testing.T) {
-	length := int64(100)
-	checkSubTasksOffset := GetPhaseVersionOffset(PhaseAssembleFinalOutput, length)
-	discoverWriteOffset := GetPhaseVersionOffset(PhaseWriteToDiscovery, length)
-	// There are 9 possible core.Phases, from PhaseUndefined to PhasePermanentFailure
-	assert.Equal(t, uint32(length*9), discoverWriteOffset-checkSubTasksOffset)
-}
-
 func TestInvertBitSet(t *testing.T) {
 	input := bitarray.NewBitSet(4)
 	input.Set(0)
@@ -125,7 +117,7 @@ func TestMapArrayStateToPluginPhase(t *testing.T) {
 		phaseInfo, err := MapArrayStateToPluginPhase(ctx, &s, nil, subTaskIDs)
 		assert.NoError(t, err)
 		assert.Equal(t, core.PhaseRunning, phaseInfo.Phase())
-		assert.Equal(t, uint32(368), phaseInfo.Version())
+		assert.Equal(t, uint32(12), phaseInfo.Version())
 		assertTaskExternalResources(t, subTaskIDs, &retryAttemptsArray, &detailedArray, phaseInfo.Info().ExternalResources)
 	})
 
@@ -145,7 +137,7 @@ func TestMapArrayStateToPluginPhase(t *testing.T) {
 		phaseInfo, err := MapArrayStateToPluginPhase(ctx, &s, nil, subTaskIDs)
 		assert.NoError(t, err)
 		assert.Equal(t, core.PhaseRunning, phaseInfo.Phase())
-		assert.Equal(t, uint32(548), phaseInfo.Version())
+		assert.Equal(t, uint32(14), phaseInfo.Version())
 		assertTaskExternalResources(t, subTaskIDs, &retryAttemptsArray, &detailedArray, phaseInfo.Info().ExternalResources)
 	})
 

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -87,7 +87,6 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 	var logLinks []*idlCore.TaskLog
 	var subTaskIDs []*string
 
-	
 	switch p, version := pluginState.GetPhase(); p {
 	case arrayCore.PhaseStart:
 		nextState, err = array.DetermineDiscoverability(ctx, tCtx, pluginState)

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -93,7 +93,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		nextState, err = array.DetermineDiscoverability(ctx, tCtx, pluginState)
 
 	case arrayCore.PhasePreLaunch:
-		nextState = pluginState.SetPhase(arrayCore.PhaseLaunch, version).SetReason("Nothing to do in PreLaunch phase.")
+		nextState = pluginState.SetPhase(arrayCore.PhaseLaunch, core.DefaultPhaseVersion).SetReason("Nothing to do in PreLaunch phase.")
 		err = nil
 
 	case arrayCore.PhaseWaitingForResources:
@@ -103,11 +103,10 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		// In order to maintain backwards compatibility with the state transitions
 		// in the aws batch plugin. Forward to PhaseCheckingSubTasksExecutions where the launching
 		// is actually occurring.
-		nextState = pluginState.SetPhase(arrayCore.PhaseCheckingSubTaskExecutions, version).SetReason("Nothing to do in Launch phase.")
+		nextState = pluginState.SetPhase(arrayCore.PhaseCheckingSubTaskExecutions, core.DefaultPhaseVersion).SetReason("Nothing to do in Launch phase.")
 		err = nil
 
 	case arrayCore.PhaseCheckingSubTaskExecutions:
-
 		nextState, logLinks, subTaskIDs, err = LaunchAndCheckSubTasksState(ctx, tCtx, e.kubeClient, pluginConfig,
 			tCtx.DataStore(), tCtx.OutputWriter().GetOutputPrefixPath(), tCtx.OutputWriter().GetRawOutputPrefix(), pluginState)
 

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -129,6 +129,11 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 	currentParallelism := 0
 	maxParallelism := int(arrayJob.Parallelism)
 
+	currentSubTaskPhaseHash, err := currentState.GetArrayStatus().HashCode()
+	if err != nil {
+		return currentState, logLinks, subTaskIDs, err
+	}
+
 	for childIdx, existingPhaseIdx := range currentState.GetArrayStatus().Detailed.GetItems() {
 		existingPhase := core.Phases[existingPhaseIdx]
 		retryAttempt := currentState.RetryAttempts.GetItem(childIdx)
@@ -246,17 +251,20 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		newState = newState.SetReason(errorMsg)
 	}
 
+	_, version := currentState.GetPhase()
 	if phase == arrayCore.PhaseCheckingSubTaskExecutions {
-		newPhaseVersion := uint32(0)
-
-		// For now, the only changes to PhaseVersion and PreviousSummary occur for running array jobs.
-		for phase, count := range newState.GetArrayStatus().Summary {
-			newPhaseVersion += uint32(phase) * uint32(count)
+		newSubTaskPhaseHash, err := newState.GetArrayStatus().HashCode()
+		if err != nil {
+			return currentState, logLinks, subTaskIDs, err
 		}
 
-		newState = newState.SetPhase(phase, newPhaseVersion).SetReason("Task is still running.")
+		if newSubTaskPhaseHash != currentSubTaskPhaseHash {
+			version++
+		}
+
+		newState = newState.SetPhase(phase, version).SetReason("Task is still running")
 	} else {
-		newState = newState.SetPhase(phase, core.DefaultPhaseVersion)
+		newState = newState.SetPhase(phase, version)
 	}
 
 	return newState, logLinks, subTaskIDs, nil

--- a/go/tasks/plugins/array/outputs_test.go
+++ b/go/tasks/plugins/array/outputs_test.go
@@ -256,9 +256,10 @@ func TestAssembleFinalOutputs(t *testing.T) {
 		tCtx.OnMaxDatasetSizeBytes().Return(10000)
 		tCtx.OnDataStore().Return(d)
 
-		_, err = AssembleFinalOutputs(ctx, assemblyQueue, tCtx, arrayCore.PhaseSuccess, s)
+		_, err = AssembleFinalOutputs(ctx, assemblyQueue, tCtx, arrayCore.PhaseSuccess, 1, s)
 		assert.NoError(t, err)
 		assert.Equal(t, arrayCore.PhaseSuccess, s.CurrentPhase)
+		assert.Equal(t, uint32(1), s.PhaseVersion)
 		assert.False(t, called)
 	})
 
@@ -294,9 +295,10 @@ func TestAssembleFinalOutputs(t *testing.T) {
 		tCtx := &mocks3.TaskExecutionContext{}
 		tCtx.OnTaskExecutionMetadata().Return(tMeta)
 
-		_, err := AssembleFinalOutputs(ctx, assemblyQueue, tCtx, arrayCore.PhaseSuccess, s)
+		_, err := AssembleFinalOutputs(ctx, assemblyQueue, tCtx, arrayCore.PhaseSuccess, 1, s)
 		assert.NoError(t, err)
 		assert.Equal(t, arrayCore.PhaseRetryableFailure, s.CurrentPhase)
+		assert.Equal(t, uint32(0), s.PhaseVersion)
 		assert.False(t, called)
 	})
 
@@ -377,9 +379,10 @@ func TestAssembleFinalOutputs(t *testing.T) {
 		tCtx.OnDataStore().Return(ds)
 		tCtx.OnMaxDatasetSizeBytes().Return(10000)
 
-		_, err = AssembleFinalOutputs(ctx, assemblyQueue, tCtx, arrayCore.PhaseSuccess, s)
+		_, err = AssembleFinalOutputs(ctx, assemblyQueue, tCtx, arrayCore.PhaseSuccess, 1, s)
 		assert.NoError(t, err)
 		assert.Equal(t, arrayCore.PhaseSuccess, s.CurrentPhase)
+		assert.Equal(t, uint32(1), s.PhaseVersion)
 		assert.True(t, called)
 	})
 }


### PR DESCRIPTION
# TL;DR
Currently the phase version on map task subtasks may not be monotonically increasing in the event of subtask failures. This means that FlyteAdmin will not process events and therefore can miss updates on subtask phase changes, etc. This PR increments the states phase version when subtasks phases are updates and then uses this value to ensure that all events are properly reported and processed by FlyteAdmin.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2288

## Follow-up issue
_NA_
