### PR TITLE
Support intra-task checkpointing in map tasks.

### DIFF
--- a/go/tasks/plugins/array/catalog.go
+++ b/go/tasks/plugins/array/catalog.go
@@ -488,7 +488,8 @@ func ConstructOutputWriter(ctx context.Context, dataStore *storage.DataStore, ou
 		return nil, err
 	}
 
-	// TODO when we fix https://github.com/flyteorg/flyte/issues/1276 we should make sure that the checkpoint paths are computed correctly
+	// checkpoint paths are not computed here because this function is only called when writing
+	// existing cached outputs. if this functionality changes this will need to be revisited.
 	p := ioutils.NewCheckpointRemoteFilePaths(ctx, dataStore, dataReference, ioutils.NewRawOutputPaths(ctx, outputSandbox), "")
 	return ioutils.NewRemoteFileOutputWriter(ctx, dataStore, p), nil
 }
@@ -523,7 +524,8 @@ func ConstructOutputReader(ctx context.Context, dataStore *storage.DataStore, ou
 		return nil, err
 	}
 
-	// TODO when we fix https://github.com/flyteorg/flyte/issues/1276 we should make so that the checkpoint paths are computed correctly
+	// checkpoint paths are not computed here because this function is only called when writing
+	// existing cached outputs. if this functionality changes this will need to be revisited.
 	outputPath := ioutils.NewCheckpointRemoteFilePaths(ctx, dataStore, dataReference, ioutils.NewRawOutputPaths(ctx, outputSandbox), "")
 	return ioutils.NewRemoteFileOutputReader(ctx, dataStore, outputPath, int64(999999999)), nil
 }

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -142,7 +142,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		}
 
 		originalIdx := arrayCore.CalculateOriginalIndex(childIdx, newState.GetIndexesToCache())
-		stCtx, err := newSubTaskExecutionContext(tCtx, taskTemplate, childIdx, originalIdx, retryAttempt)
+		stCtx, err := newSubTaskExecutionContext(ctx, tCtx, taskTemplate, childIdx, originalIdx, retryAttempt)
 		if err != nil {
 			return currentState, logLinks, subTaskIDs, err
 		}
@@ -288,7 +288,7 @@ func TerminateSubTasks(ctx context.Context, tCtx core.TaskExecutionContext, kube
 		}
 
 		originalIdx := arrayCore.CalculateOriginalIndex(childIdx, currentState.GetIndexesToCache())
-		stCtx, err := newSubTaskExecutionContext(tCtx, taskTemplate, childIdx, originalIdx, retryAttempt)
+		stCtx, err := newSubTaskExecutionContext(ctx, tCtx, taskTemplate, childIdx, originalIdx, retryAttempt)
 		if err != nil {
 			return err
 		}

--- a/go/tasks/plugins/array/k8s/management_test.go
+++ b/go/tasks/plugins/array/k8s/management_test.go
@@ -106,8 +106,8 @@ func getMockTaskExecutionContext(ctx context.Context, parallelism int) *mocks.Ta
 	ir.OnGetMatch(mock.Anything).Return(&core2.LiteralMap{}, nil)
 
 	dataStore := &storage.DataStore{
-		&stdmocks.ComposedProtobufStore{},
-		&storage.URLPathConstructor{},
+		ComposedProtobufStore: &stdmocks.ComposedProtobufStore{},
+		ReferenceConstructor:  &storage.URLPathConstructor{},
 	}
 
 	tCtx := &mocks.TaskExecutionContext{}

--- a/go/tasks/plugins/array/k8s/management_test.go
+++ b/go/tasks/plugins/array/k8s/management_test.go
@@ -16,6 +16,8 @@ import (
 	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
 
 	"github.com/flyteorg/flytestdlib/bitarray"
+	"github.com/flyteorg/flytestdlib/storage"
+	stdmocks "github.com/flyteorg/flytestdlib/storage/mocks"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -103,11 +105,17 @@ func getMockTaskExecutionContext(ctx context.Context, parallelism int) *mocks.Ta
 	ir.OnGetInputPath().Return("/prefix/inputs.pb")
 	ir.OnGetMatch(mock.Anything).Return(&core2.LiteralMap{}, nil)
 
+	dataStore := &storage.DataStore{
+		&stdmocks.ComposedProtobufStore{},
+		&storage.URLPathConstructor{},
+	}
+
 	tCtx := &mocks.TaskExecutionContext{}
 	tCtx.OnTaskReader().Return(tr)
 	tCtx.OnTaskExecutionMetadata().Return(tMeta)
 	tCtx.OnOutputWriter().Return(ow)
 	tCtx.OnInputReader().Return(ir)
+	tCtx.OnDataStore().Return(dataStore)
 	return tCtx
 }
 

--- a/go/tasks/plugins/array/k8s/subtask_exec_context.go
+++ b/go/tasks/plugins/array/k8s/subtask_exec_context.go
@@ -116,7 +116,7 @@ func newSubTaskExecutionContext(ctx context.Context, tCtx pluginsCore.TaskExecut
 	if retryAttempt == 0 {
 		prevCheckpoint = ""
 	} else {
-		prevCheckpoint, err = dataStore.ConstructReference(ctx, checkpointPrefix, strconv.FormatUint(retryAttempt - 1, 10))
+		prevCheckpoint, err = dataStore.ConstructReference(ctx, checkpointPrefix, strconv.FormatUint(retryAttempt-1, 10))
 		if err != nil {
 			return SubTaskExecutionContext{}, err
 		}

--- a/go/tasks/plugins/array/k8s/subtask_exec_context_test.go
+++ b/go/tasks/plugins/array/k8s/subtask_exec_context_test.go
@@ -7,6 +7,8 @@ import (
 
 	podPlugin "github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/pod"
 
+	"github.com/flyteorg/flytestdlib/storage"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,7 +23,7 @@ func TestSubTaskExecutionContext(t *testing.T) {
 	originalIndex := 5
 	retryAttempt := uint64(1)
 
-	stCtx, err := newSubTaskExecutionContext(tCtx, taskTemplate, executionIndex, originalIndex, retryAttempt)
+	stCtx, err := newSubTaskExecutionContext(ctx, tCtx, taskTemplate, executionIndex, originalIndex, retryAttempt)
 	assert.Nil(t, err)
 
 	assert.Equal(t, stCtx.TaskExecutionMetadata().GetTaskExecutionID().GetGeneratedName(), fmt.Sprintf("notfound-%d-%d", executionIndex, retryAttempt))
@@ -30,4 +32,6 @@ func TestSubTaskExecutionContext(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, int32(2), subtaskTemplate.TaskTypeVersion)
 	assert.Equal(t, podPlugin.ContainerTaskType, subtaskTemplate.Type)
+	assert.Equal(t, storage.DataReference("/prefix/"), stCtx.OutputWriter().GetOutputPrefixPath())
+	assert.Equal(t, storage.DataReference("/raw_prefix/5/1"), stCtx.OutputWriter().GetRawOutputPrefix())
 }


### PR DESCRIPTION
# TL;DR
Setting the correct checkpoint paths when executing map tasks using intra-task checkpointing.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
We create a new OutputWriter in the SubTaskExecutionContext which allows us to set new checkpoint paths. We can not use the existing ConstructOutputWriter function to created this OutputWriter because that [appends the original index to the output prefix](https://github.com/flyteorg/flyteplugins/blob/afb7cb345aa916a05c52d59cb15a3002482e837f/go/tasks/plugins/array/catalog.go#L486). In this case it works because this functions is only called when processing cached data. Normally flytekit [appends the original index](https://github.com/flyteorg/flytekit/blob/3cfbb71779c44cf33866b45b22f71ffc2d607d92/flytekit/bin/entrypoint.py#L390). If we reuse this function then the index will be doubly appended.

Additionally, because we can not retrieve fields specific to the NodeExecutionContext within flyteplugins we use the existing raw output prefix and append the subtask original index and retry attempt to compute each subtask retry checkpoint. This results in checkpoint paths like "s3://my-bucket/ki/unique-node-0/0/1/_flytecheckpoint" for subtask 0, retry attempt 1 of the map task node unique-node-0. It is very difficult to discern whether refactoring is necessary for a more concise path.

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2325

## Follow-up issue
_NA_
