### PR TITLE
Writing errors for subtask failures

### DIFF
--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -10,6 +10,8 @@ import (
 	"github.com/flyteorg/flyteplugins/go/tasks/errors"
 	"github.com/flyteorg/flyteplugins/go/tasks/logs"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array"
 	"github.com/flyteorg/flyteplugins/go/tasks/plugins/array/arraystatus"
 	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
@@ -211,6 +213,30 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 
 		if phaseInfo.Err() != nil {
 			messageCollector.Collect(childIdx, phaseInfo.Err().String())
+
+			// If the service reported an error but there is no error.pb written, write one with the
+			// service-provided error message.
+			or, err := array.ConstructOutputReader(ctx, dataStore, outputPrefix, baseOutputDataSandbox, originalIdx)
+			if err != nil {
+				return currentState, externalResources, err
+			}
+
+			if hasErr, err := or.IsError(ctx); err != nil {
+				return currentState, externalResources, err
+			} else if !hasErr {
+				// The subtask has not produced an error.pb, write one.
+				ow, err := array.ConstructOutputWriter(ctx, dataStore, outputPrefix, baseOutputDataSandbox, originalIdx)
+				if err != nil {
+					return currentState, externalResources, err
+				}
+
+				if err = ow.Put(ctx, ioutils.NewInMemoryOutputReader(nil, &io.ExecutionError{
+					ExecutionError: phaseInfo.Err(),
+					IsRecoverable: false, // TODO hamersaw - fix this!
+				})); err != nil {
+					return currentState, externalResources, err
+				}
+			}
 		}
 
 		if phaseInfo.Err() != nil && phaseInfo.Err().GetKind() == idlCore.ExecutionError_SYSTEM {
@@ -250,10 +276,6 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 		}
 
 		// process phaseInfo
-		if phaseInfo.Err() != nil {
-			messageCollector.Collect(childIdx, phaseInfo.Err().String())
-		}
-
 		var logLinks []*idlCore.TaskLog
 		if phaseInfo.Info() != nil {
 			logLinks = phaseInfo.Info().Logs

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -232,7 +232,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 
 				if err = ow.Put(ctx, ioutils.NewInMemoryOutputReader(nil, &io.ExecutionError{
 					ExecutionError: phaseInfo.Err(),
-					IsRecoverable: phaseInfo.Phase() != core.PhasePermanentFailure,
+					IsRecoverable:  phaseInfo.Phase() != core.PhasePermanentFailure,
 				})); err != nil {
 					return currentState, externalResources, err
 				}

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -232,7 +232,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 
 				if err = ow.Put(ctx, ioutils.NewInMemoryOutputReader(nil, &io.ExecutionError{
 					ExecutionError: phaseInfo.Err(),
-					IsRecoverable: false, // TODO hamersaw - fix this!
+					IsRecoverable: phaseInfo.Phase() != core.PhasePermanentFailure,
 				})); err != nil {
 					return currentState, externalResources, err
 				}

--- a/go/tasks/plugins/array/k8s/subtask.go
+++ b/go/tasks/plugins/array/k8s/subtask.go
@@ -189,6 +189,7 @@ func launchSubtask(ctx context.Context, stCtx SubTaskExecutionContext, cfg *Conf
 
 	logger.Infof(ctx, "Creating Object: Type:[%v], Object:[%v/%v]", pod.GetObjectKind().GroupVersionKind(), pod.GetNamespace(), pod.GetName())
 	err = kubeClient.GetClient().Create(ctx, pod)
+	//logger.Infof(ctx, "HAMERSAW - %v", err)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		if k8serrors.IsForbidden(err) {
 			if strings.Contains(err.Error(), "exceeded quota") {
@@ -198,7 +199,7 @@ func launchSubtask(ctx context.Context, stCtx SubTaskExecutionContext, cfg *Conf
 			return pluginsCore.PhaseInfoRetryableFailure("RuntimeFailure", err.Error(), nil), nil
 		} else if k8serrors.IsBadRequest(err) || k8serrors.IsInvalid(err) {
 			logger.Errorf(ctx, "Badly formatted resource for plugin [%s], err %s", executorName, err)
-			// return pluginsCore.DoTransition(pluginsCore.PhaseInfoFailure("BadTaskFormat", err.Error(), nil)), nil
+			return pluginsCore.PhaseInfoFailure("BadTaskFormat", err.Error(), nil), nil
 		} else if k8serrors.IsRequestEntityTooLargeError(err) {
 			logger.Errorf(ctx, "Badly formatted resource for plugin [%s], err %s", executorName, err)
 			return pluginsCore.PhaseInfoFailure("EntityTooLarge", err.Error(), nil), nil

--- a/go/tasks/plugins/array/k8s/subtask.go
+++ b/go/tasks/plugins/array/k8s/subtask.go
@@ -189,7 +189,6 @@ func launchSubtask(ctx context.Context, stCtx SubTaskExecutionContext, cfg *Conf
 
 	logger.Infof(ctx, "Creating Object: Type:[%v], Object:[%v/%v]", pod.GetObjectKind().GroupVersionKind(), pod.GetNamespace(), pod.GetName())
 	err = kubeClient.GetClient().Create(ctx, pod)
-	//logger.Infof(ctx, "HAMERSAW - %v", err)
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		if k8serrors.IsForbidden(err) {
 			if strings.Contains(err.Error(), "exceeded quota") {


### PR DESCRIPTION
# TL;DR
Currently the k8s-array plugin fails to correctly write error information during subtask failures. This PR checks if the error.pb file exists and if not creates one with the error message. This is code taken directly from the aws_batch plugin, which seems to handle these failures correctly.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
