### PR TITLE
Fix "golangci-lint: not found" error in master "Run tests and lint" job

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,6 +49,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: "0"
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.18'
       - name: Unit Tests
         run: make install && make test_unit_codecov
       - name: Push CodeCov

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.18'
+#      - name: Set up Go
+#        uses: actions/setup-go@v2
+#        with:
+#          go-version: '1.18'
       - name: Unit Tests
         run: make install && make test_unit_codecov
       - name: Push CodeCov

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-#      - name: Set up Go
-#        uses: actions/setup-go@v2
-#        with:
-#          go-version: '1.18'
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.18'
       - name: Unit Tests
         run: make install && make test_unit_codecov
       - name: Push CodeCov


### PR DESCRIPTION
# TL;DR
The "golangci-lint: not found" error in master workflow https://github.com/flyteorg/flyteplugins/runs/6721158969?check_suite_focus=true#step:5:36 is possibly cause by missing the "Set up Go" step which installs Go 1.18. I managed to repro the error by removing the "Set up Go" step in PR checks https://github.com/flyteorg/flyteplugins/runs/6721252164?check_suite_focus=true#step:5:27


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue

## Follow-up issue
_NA_