### PR TITLE
Pass K8sPluginConfig to spark driver and executor pods #patch

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -24,8 +24,8 @@ const OOMKilled = "OOMKilled"
 const Interrupted = "Interrupted"
 const SIGKILL = 137
 
-// ApplyInterruptibleNodeAffinity configures the node-affinity for the pod using the configuration specified.
-func ApplyInterruptibleNodeAffinity(interruptible bool, podSpec *v1.PodSpec) {
+// ApplyInterruptibleNodeSelectorRequirement configures the node selector requirement of the node-affinity using the configuration specified.
+func ApplyInterruptibleNodeSelectorRequirement(interruptible bool, affinity *v1.Affinity) {
 	// Determine node selector terms to add to node affinity
 	var nodeSelectorRequirement v1.NodeSelectorRequirement
 	if interruptible {
@@ -40,24 +40,31 @@ func ApplyInterruptibleNodeAffinity(interruptible bool, podSpec *v1.PodSpec) {
 		nodeSelectorRequirement = *config.GetK8sPluginConfig().NonInterruptibleNodeSelectorRequirement
 	}
 
-	if podSpec.Affinity == nil {
-		podSpec.Affinity = &v1.Affinity{}
+	if affinity.NodeAffinity == nil {
+		affinity.NodeAffinity = &v1.NodeAffinity{}
 	}
-	if podSpec.Affinity.NodeAffinity == nil {
-		podSpec.Affinity.NodeAffinity = &v1.NodeAffinity{}
+	if affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
 	}
-	if podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
-		podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &v1.NodeSelector{}
-	}
-	if len(podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) > 0 {
-		nodeSelectorTerms := podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
+	if len(affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) > 0 {
+		nodeSelectorTerms := affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
 		for i := range nodeSelectorTerms {
 			nst := &nodeSelectorTerms[i]
 			nst.MatchExpressions = append(nst.MatchExpressions, nodeSelectorRequirement)
 		}
 	} else {
-		podSpec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []v1.NodeSelectorTerm{v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{nodeSelectorRequirement}}}
+		affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []v1.NodeSelectorTerm{v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{nodeSelectorRequirement}}}
 	}
+
+}
+
+// ApplyInterruptibleNodeAffinity configures the node-affinity for the pod using the configuration specified.
+func ApplyInterruptibleNodeAffinity(interruptible bool, podSpec *v1.PodSpec) {
+	if podSpec.Affinity == nil {
+		podSpec.Affinity = &v1.Affinity{}
+	}
+
+	ApplyInterruptibleNodeSelectorRequirement(interruptible, podSpec.Affinity)
 }
 
 // UpdatePod updates the base pod spec used to execute tasks. This is configured with plugins and task metadata-specific options

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -104,6 +104,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 	}
 	driverSpec := sparkOp.DriverSpec{
 		SparkPodSpec: sparkOp.SparkPodSpec{
+			Affinity:         config.GetK8sPluginConfig().DefaultAffinity,
 			Annotations:      annotations,
 			Labels:           labels,
 			EnvVars:          sparkEnvVars,
@@ -120,6 +121,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 
 	executorSpec := sparkOp.ExecutorSpec{
 		SparkPodSpec: sparkOp.SparkPodSpec{
+			Affinity:         config.GetK8sPluginConfig().DefaultAffinity,
 			Annotations:      annotations,
 			Labels:           labels,
 			Image:            &container.Image,

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -240,7 +240,8 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 		j.Spec.MainClass = &sparkJob.MainClass
 	}
 
-	// Add Tolerations/NodeSelector to only Executor pods.
+	// Add Interruptible Tolerations/NodeSelector to only Executor pods.
+	// The Interruptible NodeSelector takes precedence over the DefaultNodeSelector
 	if taskCtx.TaskExecutionMetadata().IsInterruptible() {
 		j.Spec.Executor.Tolerations = append(j.Spec.Executor.Tolerations, config.GetK8sPluginConfig().InterruptibleTolerations...)
 		j.Spec.Executor.NodeSelector = config.GetK8sPluginConfig().InterruptibleNodeSelector

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -105,6 +105,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 			Image:            &container.Image,
 			SecurityContenxt: config.GetK8sPluginConfig().DefaultPodSecurityContext.DeepCopy(),
 			DNSConfig:        config.GetK8sPluginConfig().DefaultPodDNSConfig.DeepCopy(),
+			Tolerations:      config.GetK8sPluginConfig().DefaultTolerations,
 		},
 		ServiceAccount: &serviceAccountName,
 	}
@@ -117,6 +118,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 			EnvVars:          sparkEnvVars,
 			SecurityContenxt: config.GetK8sPluginConfig().DefaultPodSecurityContext.DeepCopy(),
 			DNSConfig:        config.GetK8sPluginConfig().DefaultPodDNSConfig.DeepCopy(),
+			Tolerations:      config.GetK8sPluginConfig().DefaultTolerations,
 		},
 	}
 
@@ -227,9 +229,10 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 
 	// Add Tolerations/NodeSelector to only Executor pods.
 	if taskCtx.TaskExecutionMetadata().IsInterruptible() {
-		j.Spec.Executor.Tolerations = config.GetK8sPluginConfig().InterruptibleTolerations
+		j.Spec.Executor.Tolerations = append(j.Spec.Executor.Tolerations, config.GetK8sPluginConfig().InterruptibleTolerations...)
 		j.Spec.Executor.NodeSelector = config.GetK8sPluginConfig().InterruptibleNodeSelector
 	}
+
 	return j, nil
 }
 

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -108,6 +108,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 			Tolerations:      config.GetK8sPluginConfig().DefaultTolerations,
 			SchedulerName:    &config.GetK8sPluginConfig().SchedulerName,
 			NodeSelector:     config.GetK8sPluginConfig().DefaultNodeSelector,
+			HostNetwork:      config.GetK8sPluginConfig().EnableHostNetworkingPod,
 		},
 		ServiceAccount: &serviceAccountName,
 	}
@@ -123,6 +124,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 			Tolerations:      config.GetK8sPluginConfig().DefaultTolerations,
 			SchedulerName:    &config.GetK8sPluginConfig().SchedulerName,
 			NodeSelector:     config.GetK8sPluginConfig().DefaultNodeSelector,
+			HostNetwork:      config.GetK8sPluginConfig().EnableHostNetworkingPod,
 		},
 	}
 

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -107,6 +107,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 			DNSConfig:        config.GetK8sPluginConfig().DefaultPodDNSConfig.DeepCopy(),
 			Tolerations:      config.GetK8sPluginConfig().DefaultTolerations,
 			SchedulerName:    &config.GetK8sPluginConfig().SchedulerName,
+			NodeSelector:     config.GetK8sPluginConfig().DefaultNodeSelector,
 		},
 		ServiceAccount: &serviceAccountName,
 	}
@@ -121,6 +122,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 			DNSConfig:        config.GetK8sPluginConfig().DefaultPodDNSConfig.DeepCopy(),
 			Tolerations:      config.GetK8sPluginConfig().DefaultTolerations,
 			SchedulerName:    &config.GetK8sPluginConfig().SchedulerName,
+			NodeSelector:     config.GetK8sPluginConfig().DefaultNodeSelector,
 		},
 	}
 

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -91,10 +91,6 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 		sparkEnvVars[envVar.Name] = envVar.Value
 	}
 
-	for k, v := range config.GetK8sPluginConfig().DefaultEnvVarsFromEnv {
-		sparkEnvVars[k] = v
-	}
-
 	sparkEnvVars["FLYTE_MAX_ATTEMPTS"] = strconv.Itoa(int(taskCtx.TaskExecutionMetadata().GetMaxAttempts()))
 
 	serviceAccountName := flytek8s.GetServiceAccountNameFromTaskExecutionMetadata(taskCtx.TaskExecutionMetadata())

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -90,6 +90,11 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 	for _, envVar := range envVars {
 		sparkEnvVars[envVar.Name] = envVar.Value
 	}
+
+	for k, v := range config.GetK8sPluginConfig().DefaultEnvVarsFromEnv {
+		sparkEnvVars[k] = v
+	}
+
 	sparkEnvVars["FLYTE_MAX_ATTEMPTS"] = strconv.Itoa(int(taskCtx.TaskExecutionMetadata().GetMaxAttempts()))
 
 	serviceAccountName := flytek8s.GetServiceAccountNameFromTaskExecutionMetadata(taskCtx.TaskExecutionMetadata())

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -106,6 +106,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 			SecurityContenxt: config.GetK8sPluginConfig().DefaultPodSecurityContext.DeepCopy(),
 			DNSConfig:        config.GetK8sPluginConfig().DefaultPodDNSConfig.DeepCopy(),
 			Tolerations:      config.GetK8sPluginConfig().DefaultTolerations,
+			SchedulerName:    &config.GetK8sPluginConfig().SchedulerName,
 		},
 		ServiceAccount: &serviceAccountName,
 	}
@@ -119,6 +120,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 			SecurityContenxt: config.GetK8sPluginConfig().DefaultPodSecurityContext.DeepCopy(),
 			DNSConfig:        config.GetK8sPluginConfig().DefaultPodDNSConfig.DeepCopy(),
 			Tolerations:      config.GetK8sPluginConfig().DefaultTolerations,
+			SchedulerName:    &config.GetK8sPluginConfig().SchedulerName,
 		},
 	}
 

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -117,7 +117,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 
 	executorSpec := sparkOp.ExecutorSpec{
 		SparkPodSpec: sparkOp.SparkPodSpec{
-			Affinity:         config.GetK8sPluginConfig().DefaultAffinity,
+			Affinity:         config.GetK8sPluginConfig().DefaultAffinity.DeepCopy(),
 			Annotations:      annotations,
 			Labels:           labels,
 			Image:            &container.Image,
@@ -242,6 +242,9 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 		j.Spec.Executor.Tolerations = append(j.Spec.Executor.Tolerations, config.GetK8sPluginConfig().InterruptibleTolerations...)
 		j.Spec.Executor.NodeSelector = config.GetK8sPluginConfig().InterruptibleNodeSelector
 	}
+
+	// Add interruptible/non-interruptible node selector requirements to executor pod
+	flytek8s.ApplyInterruptibleNodeSelectorRequirement(taskCtx.TaskExecutionMetadata().IsInterruptible(), j.Spec.Executor.Affinity)
 
 	return j, nil
 }

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -370,6 +370,9 @@ func TestBuildResourceSpark(t *testing.T) {
 	defaultEnvVars := make(map[string]string)
 	defaultEnvVars["foo"] = "bar"
 
+	defaultEnvVarsFromEnv := make(map[string]string)
+	defaultEnvVarsFromEnv["fooEnv"] = "barEnv"
+
 	assert.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{
 		DefaultPodSecurityContext: &corev1.PodSecurityContext{
 			RunAsUser: &runAsUser,
@@ -416,6 +419,7 @@ func TestBuildResourceSpark(t *testing.T) {
 		SchedulerName:           schedulerName,
 		EnableHostNetworkingPod: &defaultPodHostNetwork,
 		DefaultEnvVars:          defaultEnvVars,
+		DefaultEnvVarsFromEnv:   defaultEnvVarsFromEnv,
 	}),
 	)
 	resource, err := sparkResourceHandler.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, true))
@@ -532,6 +536,8 @@ func TestBuildResourceSpark(t *testing.T) {
 	assert.Equal(t, len(sparkApp.Spec.Driver.EnvVars["FLYTE_MAX_ATTEMPTS"]), 1)
 	assert.Equal(t, sparkApp.Spec.Driver.EnvVars["foo"], defaultEnvVars["foo"])
 	assert.Equal(t, sparkApp.Spec.Executor.EnvVars["foo"], defaultEnvVars["foo"])
+	assert.Equal(t, sparkApp.Spec.Driver.EnvVars["fooEnv"], defaultEnvVarsFromEnv["fooEnv"])
+	assert.Equal(t, sparkApp.Spec.Executor.EnvVars["fooEnv"], defaultEnvVarsFromEnv["fooEnv"])
 
 	// Case 2: Driver/Executor request cores set.
 	dummyConfWithRequest := make(map[string]string)

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -353,6 +353,10 @@ func TestBuildResourceSpark(t *testing.T) {
 	dnsOptVal1 := "1"
 	dnsOptVal2 := "1"
 	dnsOptVal3 := "3"
+
+	// Set scheduler
+	schedulerName := "custom-scheduler"
+
 	assert.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{
 		DefaultPodSecurityContext: &corev1.PodSecurityContext{
 			RunAsUser: &runAsUser,
@@ -396,7 +400,9 @@ func TestBuildResourceSpark(t *testing.T) {
 				Operator: "Equal",
 				Effect:   "NoSchedule",
 			},
-		}}),
+		},
+		SchedulerName: schedulerName,
+	}),
 	)
 	resource, err := sparkResourceHandler.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, true))
 	assert.Nil(t, err)
@@ -446,6 +452,8 @@ func TestBuildResourceSpark(t *testing.T) {
 	assert.Equal(t, dummySparkConf["spark.driver.memory"], *sparkApp.Spec.Driver.Memory)
 	assert.Equal(t, dummySparkConf["spark.executor.memory"], *sparkApp.Spec.Executor.Memory)
 	assert.Equal(t, dummySparkConf["spark.batchScheduler"], *sparkApp.Spec.BatchScheduler)
+	assert.Equal(t, schedulerName, *sparkApp.Spec.Executor.SchedulerName)
+	assert.Equal(t, schedulerName, *sparkApp.Spec.Driver.SchedulerName)
 
 	// Validate Interruptible Toleration and NodeSelector set for Executor but not Driver.
 	assert.Equal(t, 1, len(sparkApp.Spec.Driver.Tolerations))

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -3,6 +3,7 @@ package spark
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 	"testing"
 
@@ -367,11 +368,16 @@ func TestBuildResourceSpark(t *testing.T) {
 
 	defaultPodHostNetwork := true
 
+	// Default env vars passed explicitly and default env vars derived from environment
 	defaultEnvVars := make(map[string]string)
 	defaultEnvVars["foo"] = "bar"
 
 	defaultEnvVarsFromEnv := make(map[string]string)
-	defaultEnvVarsFromEnv["fooEnv"] = "barEnv"
+	target_key_from_env := "TEST_VAR_FROM_ENV_KEY"
+	target_value_from_env := "TEST_VAR_FROM_ENV_VALUE"
+	os.Setenv(target_key_from_env, target_value_from_env)
+	defer os.Unsetenv(target_key_from_env)
+	defaultEnvVarsFromEnv["fooEnv"] = target_key_from_env
 
 	// Default affinity/anti-affinity
 	defaultAffinity := &corev1.Affinity{
@@ -559,8 +565,8 @@ func TestBuildResourceSpark(t *testing.T) {
 	assert.Equal(t, len(sparkApp.Spec.Driver.EnvVars["FLYTE_MAX_ATTEMPTS"]), 1)
 	assert.Equal(t, sparkApp.Spec.Driver.EnvVars["foo"], defaultEnvVars["foo"])
 	assert.Equal(t, sparkApp.Spec.Executor.EnvVars["foo"], defaultEnvVars["foo"])
-	assert.Equal(t, sparkApp.Spec.Driver.EnvVars["fooEnv"], defaultEnvVarsFromEnv["fooEnv"])
-	assert.Equal(t, sparkApp.Spec.Executor.EnvVars["fooEnv"], defaultEnvVarsFromEnv["fooEnv"])
+	assert.Equal(t, sparkApp.Spec.Driver.EnvVars["fooEnv"], target_value_from_env)
+	assert.Equal(t, sparkApp.Spec.Executor.EnvVars["fooEnv"], target_value_from_env)
 	assert.Equal(t, sparkApp.Spec.Driver.Affinity, defaultAffinity)
 	assert.Equal(t, sparkApp.Spec.Executor.Affinity, defaultAffinity)
 

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -495,7 +495,10 @@ func TestBuildResourceSpark(t *testing.T) {
 	assert.Equal(t, defaultPodHostNetwork, *sparkApp.Spec.Executor.HostNetwork)
 	assert.Equal(t, defaultPodHostNetwork, *sparkApp.Spec.Driver.HostNetwork)
 
-	// Validate Interruptible Toleration and NodeSelector set for Executor but not Driver.
+	// Validate
+	// * Interruptible Toleration and NodeSelector set for Executor but not Driver.
+	// * Validate Default NodeSelector set for Driver but overwritten with Interruptible NodeSelector for Executor.
+	// * Default Tolerations set for both Driver and Executor.
 	assert.Equal(t, 1, len(sparkApp.Spec.Driver.Tolerations))
 	assert.Equal(t, 1, len(sparkApp.Spec.Driver.NodeSelector))
 	assert.Equal(t, defaultNodeSelector, sparkApp.Spec.Driver.NodeSelector)
@@ -589,6 +592,7 @@ func TestBuildResourceSpark(t *testing.T) {
 	assert.True(t, ok)
 
 	// Validate Interruptible Toleration and NodeSelector not set  for both Driver and Executors.
+	// Validate that the default Toleration and NodeSelector are set for both Driver and Executors.
 	assert.Equal(t, 1, len(sparkApp.Spec.Driver.Tolerations))
 	assert.Equal(t, 1, len(sparkApp.Spec.Driver.NodeSelector))
 	assert.Equal(t, defaultNodeSelector, sparkApp.Spec.Driver.NodeSelector)

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -373,11 +373,11 @@ func TestBuildResourceSpark(t *testing.T) {
 	defaultEnvVars["foo"] = "bar"
 
 	defaultEnvVarsFromEnv := make(map[string]string)
-	target_key_from_env := "TEST_VAR_FROM_ENV_KEY"
-	target_value_from_env := "TEST_VAR_FROM_ENV_VALUE"
-	os.Setenv(target_key_from_env, target_value_from_env)
-	defer os.Unsetenv(target_key_from_env)
-	defaultEnvVarsFromEnv["fooEnv"] = target_key_from_env
+	targetKeyFromEnv := "TEST_VAR_FROM_ENV_KEY"
+	targetValueFromEnv := "TEST_VAR_FROM_ENV_VALUE"
+	os.Setenv(targetKeyFromEnv, targetValueFromEnv)
+	defer os.Unsetenv(targetKeyFromEnv)
+	defaultEnvVarsFromEnv["fooEnv"] = targetKeyFromEnv
 
 	// Default affinity/anti-affinity
 	defaultAffinity := &corev1.Affinity{
@@ -565,8 +565,8 @@ func TestBuildResourceSpark(t *testing.T) {
 	assert.Equal(t, len(sparkApp.Spec.Driver.EnvVars["FLYTE_MAX_ATTEMPTS"]), 1)
 	assert.Equal(t, sparkApp.Spec.Driver.EnvVars["foo"], defaultEnvVars["foo"])
 	assert.Equal(t, sparkApp.Spec.Executor.EnvVars["foo"], defaultEnvVars["foo"])
-	assert.Equal(t, sparkApp.Spec.Driver.EnvVars["fooEnv"], target_value_from_env)
-	assert.Equal(t, sparkApp.Spec.Executor.EnvVars["fooEnv"], target_value_from_env)
+	assert.Equal(t, sparkApp.Spec.Driver.EnvVars["fooEnv"], targetValueFromEnv)
+	assert.Equal(t, sparkApp.Spec.Executor.EnvVars["fooEnv"], targetValueFromEnv)
 	assert.Equal(t, sparkApp.Spec.Driver.Affinity, defaultAffinity)
 	assert.Equal(t, sparkApp.Spec.Executor.Affinity, defaultAffinity)
 

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -367,6 +367,9 @@ func TestBuildResourceSpark(t *testing.T) {
 
 	defaultPodHostNetwork := true
 
+	defaultEnvVars := make(map[string]string)
+	defaultEnvVars["foo"] = "bar"
+
 	assert.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{
 		DefaultPodSecurityContext: &corev1.PodSecurityContext{
 			RunAsUser: &runAsUser,
@@ -412,6 +415,7 @@ func TestBuildResourceSpark(t *testing.T) {
 		},
 		SchedulerName:           schedulerName,
 		EnableHostNetworkingPod: &defaultPodHostNetwork,
+		DefaultEnvVars:          defaultEnvVars,
 	}),
 	)
 	resource, err := sparkResourceHandler.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, true))
@@ -526,6 +530,8 @@ func TestBuildResourceSpark(t *testing.T) {
 	assert.Equal(t, dummySparkConf["spark.flyteorg.feature3.enabled"], sparkApp.Spec.SparkConf["spark.flyteorg.feature3.enabled"])
 
 	assert.Equal(t, len(sparkApp.Spec.Driver.EnvVars["FLYTE_MAX_ATTEMPTS"]), 1)
+	assert.Equal(t, sparkApp.Spec.Driver.EnvVars["foo"], defaultEnvVars["foo"])
+	assert.Equal(t, sparkApp.Spec.Executor.EnvVars["foo"], defaultEnvVars["foo"])
 
 	// Case 2: Driver/Executor request cores set.
 	dummyConfWithRequest := make(map[string]string)

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -365,6 +365,8 @@ func TestBuildResourceSpark(t *testing.T) {
 		"x/interruptible": "true",
 	}
 
+	defaultPodHostNetwork := true
+
 	assert.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{
 		DefaultPodSecurityContext: &corev1.PodSecurityContext{
 			RunAsUser: &runAsUser,
@@ -408,7 +410,8 @@ func TestBuildResourceSpark(t *testing.T) {
 				Effect:   "NoSchedule",
 			},
 		},
-		SchedulerName: schedulerName,
+		SchedulerName:           schedulerName,
+		EnableHostNetworkingPod: &defaultPodHostNetwork,
 	}),
 	)
 	resource, err := sparkResourceHandler.BuildResource(context.TODO(), dummySparkTaskContext(taskTemplate, true))
@@ -461,6 +464,8 @@ func TestBuildResourceSpark(t *testing.T) {
 	assert.Equal(t, dummySparkConf["spark.batchScheduler"], *sparkApp.Spec.BatchScheduler)
 	assert.Equal(t, schedulerName, *sparkApp.Spec.Executor.SchedulerName)
 	assert.Equal(t, schedulerName, *sparkApp.Spec.Driver.SchedulerName)
+	assert.Equal(t, defaultPodHostNetwork, *sparkApp.Spec.Executor.HostNetwork)
+	assert.Equal(t, defaultPodHostNetwork, *sparkApp.Spec.Driver.HostNetwork)
 
 	// Validate Interruptible Toleration and NodeSelector set for Executor but not Driver.
 	assert.Equal(t, 1, len(sparkApp.Spec.Driver.Tolerations))


### PR DESCRIPTION
# TL;DR

Currently, when running Spark tasks, some of the k8s plugin config values configured in the helm values (such as for instance `DefaultTolerations`, `NodeSelector`, `HostNetwork`, `SchedulerName`, ...) are not carried over to the SparkApplication and, thus, not to the driver and executor pods.

In my specific case this is limiting because we run Flyte itself and the Spark operator on cheap nodes while giving workflows the ability to start high-powered nodes via default tolerations.

This PR fixes this issue.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Comparing the custom [SparkPodSpec](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/9aa84a418803693c13338430bbe662e402861639/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go#L440) with Flyte’s [K8sPluginConfig](https://github.com/fg91/flyteplugins/blob/2c83e24004c09329150b96e24a66f76c4fc660e1/go/tasks/pluginmachinery/flytek8s/config/config.go#L67) shows that the following configurations are already carried over to the `SparkPodSpec` of the driver and the executor:

* `DefaultAnnotations`
* `DefaultLabels`
* `InterruptibleTolerations`
* `DefaultNodeSelector` and `InterruptibleNodeSelector`
* `DefaultPodSecurityContext` ([called` SecurityContext` in `SparkPodSpec`](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/94775cd89ca0158e869fac39e1b097d1bf56a7e8/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go#L497))
* `DefaultPodDNSConfig` ([called `DNSConfig` in `SparkPodSpec`](https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/94775cd89ca0158e869fac39e1b097d1bf56a7e8/pkg/apis/sparkoperator.k8s.io/v1beta2/types.go#L519))

This PR adds logic to carry over the following configurations:

* `DefaultTolerations`
* `SchedulerName`
* `DefaultNodeSelector`
* `EnableHostNetworkingPod`
* `DefaultEnvVarsFromEnv`
* `DefaultAffinity`


## Follow-up issue

The Spark operator passes the tolerations from the `SparkApplication` along to the pods only if the operator itself is installed with the `--set webhook.enable=true` value to activate Mutating Admission Webhooks. I feel I should document this somewhere. Should I make a PR to note this [here](https://docs.flyte.org/projects/cookbook/en/stable/auto/integrations/kubernetes/k8s_spark/index.html) or would you recommend another place?
