### PR TITLE
Add OutputLocation to ResourceWrapper if bigquery job status is Done

### DIFF
--- a/go/tasks/pluginmachinery/internal/webapi/monitor.go
+++ b/go/tasks/pluginmachinery/internal/webapi/monitor.go
@@ -33,7 +33,7 @@ func monitor(ctx context.Context, tCtx core.TaskExecutionContext, p Client, cach
 	if cacheItem.Resource == nil {
 		return state, core.PhaseInfoRunning(0, nil), nil
 	}
-	
+
 	newPhase, err := p.Status(ctx, newPluginContext(cacheItem.ResourceMeta, cacheItem.Resource, "", tCtx))
 	if err != nil {
 		return nil, core.PhaseInfoUndefined, err

--- a/go/tasks/pluginmachinery/internal/webapi/monitor.go
+++ b/go/tasks/pluginmachinery/internal/webapi/monitor.go
@@ -33,7 +33,7 @@ func monitor(ctx context.Context, tCtx core.TaskExecutionContext, p Client, cach
 	if cacheItem.Resource == nil {
 		return state, core.PhaseInfoRunning(0, nil), nil
 	}
-
+	
 	newPhase, err := p.Status(ctx, newPluginContext(cacheItem.ResourceMeta, cacheItem.Resource, "", tCtx))
 	if err != nil {
 		return nil, core.PhaseInfoUndefined, err

--- a/go/tasks/plugins/webapi/bigquery/integration_test.go
+++ b/go/tasks/plugins/webapi/bigquery/integration_test.go
@@ -25,6 +25,11 @@ import (
 	"google.golang.org/api/bigquery/v2"
 )
 
+const (
+	httpPost string = "POST"
+	httpGet  string = "GET"
+)
+
 func TestEndToEnd(t *testing.T) {
 	server := newFakeBigQueryServer()
 	defer server.Close()
@@ -92,7 +97,7 @@ func TestEndToEnd(t *testing.T) {
 
 func newFakeBigQueryServer() *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.URL.Path == "/projects/flyte/jobs" && request.Method == "POST" {
+		if request.URL.Path == "/projects/flyte/jobs" && request.Method == httpPost {
 			writer.WriteHeader(200)
 			job := bigquery.Job{Status: &bigquery.JobStatus{State: bigqueryStatusRunning}}
 			bytes, _ := json.Marshal(job)
@@ -100,7 +105,7 @@ func newFakeBigQueryServer() *httptest.Server {
 			return
 		}
 
-		if strings.HasPrefix(request.URL.Path, "/projects/flyte/jobs/") && request.Method == "GET" {
+		if strings.HasPrefix(request.URL.Path, "/projects/flyte/jobs/") && request.Method == httpGet {
 			writer.WriteHeader(200)
 			job := bigquery.Job{Status: &bigquery.JobStatus{State: bigqueryStatusDone},
 				Configuration: &bigquery.JobConfiguration{
@@ -112,7 +117,7 @@ func newFakeBigQueryServer() *httptest.Server {
 			return
 		}
 
-		if request.URL.Path == "/projects/cache/jobs" && request.Method == "POST" {
+		if request.URL.Path == "/projects/cache/jobs" && request.Method == httpPost {
 			writer.WriteHeader(200)
 			job := bigquery.Job{Status: &bigquery.JobStatus{State: bigqueryStatusDone}}
 			bytes, _ := json.Marshal(job)
@@ -120,7 +125,7 @@ func newFakeBigQueryServer() *httptest.Server {
 			return
 		}
 
-		if strings.HasPrefix(request.URL.Path, "/projects/cache/jobs/") && request.Method == "GET" {
+		if strings.HasPrefix(request.URL.Path, "/projects/cache/jobs/") && request.Method == httpGet {
 			writer.WriteHeader(200)
 			job := bigquery.Job{Status: &bigquery.JobStatus{State: bigqueryStatusDone},
 				Configuration: &bigquery.JobConfiguration{
@@ -132,7 +137,7 @@ func newFakeBigQueryServer() *httptest.Server {
 			return
 		}
 
-		if request.URL.Path == "/projects/pending/jobs" && request.Method == "POST" {
+		if request.URL.Path == "/projects/pending/jobs" && request.Method == httpPost {
 			writer.WriteHeader(200)
 			job := bigquery.Job{Status: &bigquery.JobStatus{State: bigqueryStatusPending}}
 			bytes, _ := json.Marshal(job)
@@ -140,7 +145,7 @@ func newFakeBigQueryServer() *httptest.Server {
 			return
 		}
 
-		if strings.HasPrefix(request.URL.Path, "/projects/pending/jobs/") && request.Method == "GET" {
+		if strings.HasPrefix(request.URL.Path, "/projects/pending/jobs/") && request.Method == httpGet {
 			writer.WriteHeader(200)
 			job := bigquery.Job{Status: &bigquery.JobStatus{State: bigqueryStatusDone}}
 			bytes, _ := json.Marshal(job)

--- a/go/tasks/plugins/webapi/bigquery/plugin.go
+++ b/go/tasks/plugins/webapi/bigquery/plugin.go
@@ -33,8 +33,11 @@ import (
 )
 
 const (
-	bigqueryQueryJobTask = "bigquery_query_job_task"
-	bigqueryConsolePath  = "https://console.cloud.google.com/bigquery"
+	bigqueryQueryJobTask  = "bigquery_query_job_task"
+	bigqueryConsolePath   = "https://console.cloud.google.com/bigquery"
+	bigqueryStatusRunning = "RUNNING"
+	bigqueryStatusPending = "PENDING"
+	bigqueryStatusDone    = "DONE"
 )
 
 type Plugin struct {
@@ -148,7 +151,22 @@ func (p Plugin) createImpl(ctx context.Context, taskCtx webapi.TaskExecutionCont
 		return nil, nil, pluginErrors.Wrapf(pluginErrors.RuntimeFailure, err, "failed to create query job")
 	}
 
-	resource := ResourceWrapper{Status: resp.Status}
+	var outputLocation string
+	if resp.Status != nil && resp.Status.State == bigqueryStatusDone {
+		job, err := client.Jobs.Get(job.JobReference.ProjectId, job.JobReference.JobId).Do()
+
+		if err != nil {
+			err := pluginErrors.Wrapf(
+				pluginErrors.RuntimeFailure,
+				err,
+				"failed to get job [%s]",
+				formatJobReference(*job.JobReference))
+
+			return nil, nil, err
+		}
+		outputLocation = constructOutputLocation(job)
+	}
+	resource := ResourceWrapper{Status: resp.Status, OutputLocation: outputLocation}
 	resourceMeta := ResourceMetaWrapper{
 		JobReference:      *job.JobReference,
 		Namespace:         namespace,
@@ -214,9 +232,7 @@ func (p Plugin) getImpl(ctx context.Context, taskCtx webapi.GetContext) (wrapper
 		return nil, err
 	}
 
-	dst := job.Configuration.Query.DestinationTable
-	outputLocation := fmt.Sprintf("bq://%v:%v.%v", dst.ProjectId, dst.DatasetId, dst.TableId)
-
+	outputLocation := constructOutputLocation(job)
 	return &ResourceWrapper{
 		Status:         job.Status,
 		OutputLocation: outputLocation,
@@ -267,13 +283,13 @@ func (p Plugin) Status(ctx context.Context, tCtx webapi.StatusContext) (phase co
 	}
 
 	switch resource.Status.State {
-	case "PENDING":
+	case bigqueryStatusPending:
 		return core.PhaseInfoQueuedWithTaskInfo(version, "Query is PENDING", taskInfo), nil
 
-	case "RUNNING":
+	case bigqueryStatusRunning:
 		return core.PhaseInfoRunning(version, taskInfo), nil
 
-	case "DONE":
+	case bigqueryStatusDone:
 		if resource.Status.ErrorResult != nil {
 			return handleErrorResult(
 				resource.Status.ErrorResult.Reason,
@@ -289,6 +305,14 @@ func (p Plugin) Status(ctx context.Context, tCtx webapi.StatusContext) (phase co
 	}
 
 	return core.PhaseInfoUndefined, pluginErrors.Errorf(pluginsCore.SystemErrorCode, "unknown execution phase [%v].", resource.Status.State)
+}
+
+func constructOutputLocation(job *bigquery.Job) string {
+	dst := job.Configuration.Query.DestinationTable
+	if dst == nil {
+		return ""
+	}
+	return fmt.Sprintf("bq://%v:%v.%v", dst.ProjectId, dst.DatasetId, dst.TableId)
 }
 
 func writeOutput(ctx context.Context, tCtx webapi.StatusContext, OutputLocation string) error {

--- a/go/tasks/plugins/webapi/bigquery/plugin.go
+++ b/go/tasks/plugins/webapi/bigquery/plugin.go
@@ -153,7 +153,7 @@ func (p Plugin) createImpl(ctx context.Context, taskCtx webapi.TaskExecutionCont
 
 	var outputLocation string
 	if resp.Status != nil && resp.Status.State == bigqueryStatusDone {
-		job, err := client.Jobs.Get(job.JobReference.ProjectId, job.JobReference.JobId).Do()
+		getResp, err := client.Jobs.Get(job.JobReference.ProjectId, job.JobReference.JobId).Do()
 
 		if err != nil {
 			err := pluginErrors.Wrapf(
@@ -164,7 +164,7 @@ func (p Plugin) createImpl(ctx context.Context, taskCtx webapi.TaskExecutionCont
 
 			return nil, nil, err
 		}
-		outputLocation = constructOutputLocation(job)
+		outputLocation = constructOutputLocation(getResp)
 	}
 	resource := ResourceWrapper{Status: resp.Status, OutputLocation: outputLocation}
 	resourceMeta := ResourceMetaWrapper{
@@ -308,10 +308,10 @@ func (p Plugin) Status(ctx context.Context, tCtx webapi.StatusContext) (phase co
 }
 
 func constructOutputLocation(job *bigquery.Job) string {
-	dst := job.Configuration.Query.DestinationTable
-	if dst == nil {
+	if job == nil || job.Configuration == nil || job.Configuration.Query == nil || job.Configuration.Query.DestinationTable == nil {
 		return ""
 	}
+	dst := job.Configuration.Query.DestinationTable
 	return fmt.Sprintf("bq://%v:%v.%v", dst.ProjectId, dst.DatasetId, dst.TableId)
 }
 

--- a/go/tasks/plugins/webapi/bigquery/plugin_test.go
+++ b/go/tasks/plugins/webapi/bigquery/plugin_test.go
@@ -42,6 +42,26 @@ func TestFormatJobReference(t *testing.T) {
 	})
 }
 
+func TestConstructOutputLocation(t *testing.T) {
+	job := &bigquery.Job{
+		Configuration: &bigquery.JobConfiguration{
+			Query: &bigquery.JobConfigurationQuery{
+				DestinationTable: &bigquery.TableReference{
+					ProjectId: "project",
+					DatasetId: "dataset",
+					TableId:   "table",
+				},
+			},
+		},
+	}
+	ol := constructOutputLocation(job)
+	assert.Equal(t, ol, "bq://project:dataset.table")
+
+	job.Configuration.Query.DestinationTable = nil
+	ol = constructOutputLocation(job)
+	assert.Equal(t, ol, "")
+}
+
 func TestCreateTaskInfo(t *testing.T) {
 	t.Run("create task info", func(t *testing.T) {
 		resourceMeta := ResourceMetaWrapper{

--- a/go/tasks/plugins/webapi/bigquery/plugin_test.go
+++ b/go/tasks/plugins/webapi/bigquery/plugin_test.go
@@ -54,11 +54,11 @@ func TestConstructOutputLocation(t *testing.T) {
 			},
 		},
 	}
-	ol := constructOutputLocation(job)
+	ol := constructOutputLocation(context.Background(), job)
 	assert.Equal(t, ol, "bq://project:dataset.table")
 
 	job.Configuration.Query.DestinationTable = nil
-	ol = constructOutputLocation(job)
+	ol = constructOutputLocation(context.Background(), job)
 	assert.Equal(t, ol, "")
 }
 


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
https://flyte-org.slack.com/archives/CNMKCU6FR/p1659118984659049

The problem is that BQ will [cache the query result](https://cloud.google.com/bigquery/docs/cached-results#:~:text=By%20default%2C%20BigQuery%20caches%20query,24%2Dhour%20cache%20lifetime%20applies.), so when we [create](https://github.com/flyteorg/flyteplugins/blob/f1feedeb49e2d1c103bffbbe0ad59293bc21162b/go/tasks/plugins/webapi/bigquery/plugin.go#L114) a bq task, the job status will return  “Done” instead of “running”. Because the status is done, propeller won’t invoke [get](https://github.com/flyteorg/flyteplugins/blob/46386ae52192e2984192d20d089c4a8f55103bab/go/tasks/plugins/webapi/bigquery/plugin.go#L189) which can help us construct [outputLocation](https://github.com/flyteorg/flyteplugins/blob/46386ae52192e2984192d20d089c4a8f55103bab/go/tasks/plugins/webapi/bigquery/plugin.go#L219) for structured dataset. Therefore, it causes the uri in structured dataset become empty

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Add OutputLocation to ResourceWrapper if job status is Done

<img width="1105" alt="image" src="https://user-images.githubusercontent.com/37936015/183113770-c3791d40-cb95-42b3-be82-ae0254954317.png">


## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_