### PR TITLE
Fixing cache lookup on large fanout map tasks

### DIFF
--- a/go/tasks/pluginmachinery/catalog/config.go
+++ b/go/tasks/pluginmachinery/catalog/config.go
@@ -18,12 +18,12 @@ var defaultConfig = &Config{
 	ReaderWorkqueueConfig: workqueue.Config{
 		MaxRetries:         3,
 		Workers:            10,
-		IndexCacheMaxItems: 1000,
+		IndexCacheMaxItems: 10000,
 	},
 	WriterWorkqueueConfig: workqueue.Config{
 		MaxRetries:         3,
 		Workers:            10,
-		IndexCacheMaxItems: 1000,
+		IndexCacheMaxItems: 10000,
 	},
 }
 

--- a/go/tasks/plugins/array/awsbatch/executor.go
+++ b/go/tasks/plugins/array/awsbatch/executor.go
@@ -108,8 +108,9 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 	// Always attempt to augment phase with task logs.
 	var logLinks []*idlCore.TaskLog
 	var externalResources []*core.ExternalResource
-	switch p {
-	case arrayCore.PhaseStart:
+
+	np, _ := pluginState.GetPhase()
+	if p == arrayCore.PhaseStart && np != arrayCore.PhaseStart {
 		externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, pluginState.State,
 			func(tCtx core.TaskExecutionContext, childIndex int) string {
 				// subTaskIDs for the the aws_batch are generated based on the job ID, therefore
@@ -117,7 +118,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 				return ""
 			},
 		)
-	default:
+	} else {
 		logLinks, externalResources, err = GetTaskLinks(ctx, tCtx.TaskExecutionMetadata(), e.jobStore, pluginState)
 	}
 

--- a/go/tasks/plugins/array/awsbatch/executor.go
+++ b/go/tasks/plugins/array/awsbatch/executor.go
@@ -68,7 +68,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 
 	switch p {
 	case arrayCore.PhaseStart:
-		pluginState.State, err = array.DetermineDiscoverability(ctx, tCtx, pluginState.State)
+		pluginState.State, err = array.DetermineDiscoverability(ctx, tCtx, pluginConfig.MaxArrayJobSize, pluginState.State)
 
 	case arrayCore.PhasePreLaunch:
 		pluginState, err = EnsureJobDefinition(ctx, tCtx, pluginConfig, e.jobStore.Client, e.jobDefinitionCache, pluginState)

--- a/go/tasks/plugins/array/awsbatch/executor.go
+++ b/go/tasks/plugins/array/awsbatch/executor.go
@@ -109,8 +109,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 	var logLinks []*idlCore.TaskLog
 	var externalResources []*core.ExternalResource
 
-	np, _ := pluginState.GetPhase()
-	if p == arrayCore.PhaseStart && np != arrayCore.PhaseStart {
+	if p == arrayCore.PhasePreLaunch {
 		externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, pluginState.State,
 			func(tCtx core.TaskExecutionContext, childIndex int) string {
 				// subTaskIDs for the the aws_batch are generated based on the job ID, therefore
@@ -118,7 +117,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 				return ""
 			},
 		)
-	} else {
+	} else if p != arrayCore.PhaseStart {
 		logLinks, externalResources, err = GetTaskLinks(ctx, tCtx.TaskExecutionMetadata(), e.jobStore, pluginState)
 	}
 

--- a/go/tasks/plugins/array/awsbatch/launcher.go
+++ b/go/tasks/plugins/array/awsbatch/launcher.go
@@ -19,12 +19,6 @@ import (
 func LaunchSubTasks(ctx context.Context, tCtx core.TaskExecutionContext, batchClient Client, pluginConfig *config.Config,
 	currentState *State, metrics ExecutorMetrics) (nextState *State, err error) {
 	size := currentState.GetExecutionArraySize()
-	if int64(currentState.GetExecutionArraySize()) > pluginConfig.MaxArrayJobSize {
-		ee := fmt.Errorf("array size > max allowed. Requested [%v]. Allowed [%v]", currentState.GetExecutionArraySize(), pluginConfig.MaxArrayJobSize)
-		logger.Info(ctx, ee)
-		currentState.State = currentState.SetPhase(arrayCore.PhasePermanentFailure, 0).SetReason(ee.Error())
-		return currentState, nil
-	}
 
 	jobDefinition := currentState.GetJobDefinitionArn()
 	if len(jobDefinition) == 0 {

--- a/go/tasks/plugins/array/catalog.go
+++ b/go/tasks/plugins/array/catalog.go
@@ -30,7 +30,7 @@ const AwsBatchTaskType = "aws-batch"
 // which is different than their original location. To find the original index we construct an indexLookup array.
 // The subtask can find it's original index value in indexLookup[JOB_ARRAY_INDEX] where JOB_ARRAY_INDEX is an
 // environment variable in the pod
-func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContext, state *arrayCore.State) (
+func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContext, maxArrayJobSize int64, state *arrayCore.State) (
 	*arrayCore.State, error) {
 
 	// Check that the taskTemplate is valid
@@ -109,6 +109,13 @@ func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContex
 		inputReaders = ConstructStaticInputReaders(tCtx.InputReader(), literalCollection.Literals, discoveredInputName)
 	}
 
+	if arrayJobSize > maxArrayJobSize {
+		ee := fmt.Errorf("array size > max allowed. requested [%v]. allowed [%v]", arrayJobSize, maxArrayJobSize)
+		logger.Info(ctx, ee)
+		state = state.SetPhase(arrayCore.PhasePermanentFailure, 0).SetReason(ee.Error())
+		return state, nil
+	}
+
 	// If the task is not discoverable, then skip data catalog work and move directly to launch
 	if taskTemplate.Metadata == nil || !taskTemplate.Metadata.Discoverable {
 		logger.Infof(ctx, "Task is not discoverable, moving to launch phase...")
@@ -121,12 +128,17 @@ func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContex
 	}
 
 	// Otherwise, run the data catalog steps - create and submit work items to the catalog processor,
+
+	// check that the number of items in the cache index LRU cache is greater than the number of
+	// jobs in the array. if not we will never complete the cache lookup and be stuck in an
+	// infinite loop.
 	cfg := catalog.GetConfig()
 	if int(arrayJobSize) > cfg.WriterWorkqueueConfig.IndexCacheMaxItems || int(arrayJobSize) > cfg.ReaderWorkqueueConfig.IndexCacheMaxItems {
 		ee := fmt.Errorf("array size > max allowed for cache lookup. requested [%v]. writer allowed [%v] reader allowed [%v]",
 			arrayJobSize, cfg.WriterWorkqueueConfig.IndexCacheMaxItems, cfg.ReaderWorkqueueConfig.IndexCacheMaxItems)
 		logger.Error(ctx, ee)
-		return state, ee
+		state = state.SetPhase(arrayCore.PhasePermanentFailure, 0).SetReason(ee.Error())
+		return state, nil
 	}
 
 	// build output writers

--- a/go/tasks/plugins/array/catalog.go
+++ b/go/tasks/plugins/array/catalog.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand" // TODO @hamersaw - remove for testing
 	"strconv"
 
 	idlPlugins "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
@@ -192,7 +191,6 @@ func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContex
 
 		state = state.SetPhase(arrayCore.PhasePreLaunch, core.DefaultPhaseVersion).SetReason("Finished cache lookup.")
 	case catalog.ResponseStatusNotReady:
-		logger.Infof(ctx, "HAMERSAW - not yet ready")
 		ownerSignal := tCtx.TaskRefreshIndicator()
 		future.OnReady(func(ctx context.Context, _ catalog.Future) {
 			ownerSignal(ctx)

--- a/go/tasks/plugins/array/catalog_test.go
+++ b/go/tasks/plugins/array/catalog_test.go
@@ -242,22 +242,6 @@ func TestDetermineDiscoverability(t *testing.T) {
 		}, 1, nil)
 	})
 
-	t.Run("Discoverable but not cached", func(t *testing.T) {
-		download.OnGetCachedResults().Return(bitarray.NewBitSet(1)).Once()
-		toCache := bitarray.NewBitSet(1)
-		toCache.Set(0)
-
-		runDetermineDiscoverabilityTest(t, template, f, &arrayCore.State{
-			CurrentPhase:         arrayCore.PhasePreLaunch,
-			PhaseVersion:         core2.DefaultPhaseVersion,
-			ExecutionArraySize:   1,
-			OriginalArraySize:    1,
-			OriginalMinSuccesses: 1,
-			IndexesToCache:       toCache,
-			Reason:               "Finished cache lookup.",
-		}, 1, nil)
-	})
-
 	t.Run("DiscoveryNotYetComplete ", func(t *testing.T) {
 		future := &catalogMocks.DownloadFuture{}
 		future.OnGetResponseStatus().Return(catalog.ResponseStatusNotReady)

--- a/go/tasks/plugins/array/catalog_test.go
+++ b/go/tasks/plugins/array/catalog_test.go
@@ -55,7 +55,7 @@ func TestCatalogBitsetToLiteralCollection(t *testing.T) {
 }
 
 func runDetermineDiscoverabilityTest(t testing.TB, taskTemplate *core.TaskTemplate, future catalog.DownloadFuture,
-	expectedState *arrayCore.State, expectedError error) {
+	expectedState *arrayCore.State, maxArrayJobSize int64, expectedError error) {
 
 	ctx := context.Background()
 
@@ -126,7 +126,7 @@ func runDetermineDiscoverabilityTest(t testing.TB, taskTemplate *core.TaskTempla
 		CurrentPhase: arrayCore.PhaseStart,
 	}
 
-	got, err := DetermineDiscoverability(ctx, tCtx, state)
+	got, err := DetermineDiscoverability(ctx, tCtx, maxArrayJobSize, state)
 	if expectedError != nil {
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, expectedError))
@@ -151,7 +151,7 @@ func TestDetermineDiscoverability(t *testing.T) {
 	f.OnGetResponse().Return(download, nil)
 
 	t.Run("Bad Task Spec", func(t *testing.T) {
-		runDetermineDiscoverabilityTest(t, template, f, nil, stdErrors.Errorf(pluginErrors.BadTaskSpecification, ""))
+		runDetermineDiscoverabilityTest(t, template, f, nil, 0, stdErrors.Errorf(pluginErrors.BadTaskSpecification, ""))
 	})
 
 	template = &core.TaskTemplate{
@@ -186,7 +186,7 @@ func TestDetermineDiscoverability(t *testing.T) {
 			OriginalMinSuccesses: 1,
 			IndexesToCache:       toCache,
 			Reason:               "Task is not discoverable.",
-		}, nil)
+		}, 1, nil)
 	})
 
 	t.Run("Not discoverable", func(t *testing.T) {
@@ -200,7 +200,7 @@ func TestDetermineDiscoverability(t *testing.T) {
 			OriginalMinSuccesses: 1,
 			IndexesToCache:       toCache,
 			Reason:               "Task is not discoverable.",
-		}, nil)
+		}, 1, nil)
 	})
 
 	template.Metadata = &core.TaskMetadata{
@@ -221,7 +221,7 @@ func TestDetermineDiscoverability(t *testing.T) {
 			OriginalMinSuccesses: 1,
 			IndexesToCache:       toCache,
 			Reason:               "Finished cache lookup.",
-		}, nil)
+		}, 1, nil)
 	})
 
 	t.Run("Discoverable and cached", func(t *testing.T) {
@@ -239,7 +239,7 @@ func TestDetermineDiscoverability(t *testing.T) {
 			OriginalMinSuccesses: 1,
 			IndexesToCache:       toCache,
 			Reason:               "Finished cache lookup.",
-		}, nil)
+		}, 1, nil)
 	})
 }
 
@@ -301,6 +301,6 @@ func TestDiscoverabilityTaskType1(t *testing.T) {
 			OriginalMinSuccesses: 2,
 			IndexesToCache:       toCache,
 			Reason:               "Task is not discoverable.",
-		}, nil)
+		}, 3, nil)
 	})
 }

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -86,7 +86,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 
 	switch p, version := pluginState.GetPhase(); p {
 	case arrayCore.PhaseStart:
-		nextState, err = array.DetermineDiscoverability(ctx, tCtx, pluginState)
+		nextState, err = array.DetermineDiscoverability(ctx, tCtx, pluginConfig.MaxArrayJobSize, pluginState)
 		if err != nil {
 			return core.UnknownTransition, err
 		}

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -91,12 +91,14 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 			return core.UnknownTransition, err
 		}
 
-		externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, pluginState,
-			func(tCtx core.TaskExecutionContext, childIndex int) string {
-				subTaskExecutionID := NewSubTaskExecutionID(tCtx.TaskExecutionMetadata().GetTaskExecutionID(), childIndex, 0)
-				return subTaskExecutionID.GetGeneratedName()
-			},
-		)
+		if np, _ := nextState.GetPhase(); np != arrayCore.PhaseStart {
+			externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, pluginState,
+				func(tCtx core.TaskExecutionContext, childIndex int) string {
+					subTaskExecutionID := NewSubTaskExecutionID(tCtx.TaskExecutionMetadata().GetTaskExecutionID(), childIndex, 0)
+					return subTaskExecutionID.GetGeneratedName()
+				},
+			)
+		}
 
 	case arrayCore.PhasePreLaunch:
 		nextState = pluginState.SetPhase(arrayCore.PhaseLaunch, core.DefaultPhaseVersion).SetReason("Nothing to do in PreLaunch phase.")

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -91,6 +91,11 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 			return core.UnknownTransition, err
 		}
 
+		// if the next state has not yet transitioned from PhaseStart it means that the background
+		// cache lookup for map task subtasks has not yet been completed. this is necessary for
+		// the InitializeExternalResources operation, which is used to notify admin of subtask
+		// including cache status. a transition from PhaseStart indicates cache lookup completion
+		// and we may InitializeExternalResources.
 		if np, _ := nextState.GetPhase(); np != arrayCore.PhaseStart {
 			externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, pluginState,
 				func(tCtx core.TaskExecutionContext, childIndex int) string {

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -66,12 +66,6 @@ func deallocateResource(ctx context.Context, tCtx core.TaskExecutionContext, con
 func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionContext, kubeClient core.KubeClient,
 	config *Config, dataStore *storage.DataStore, outputPrefix, baseOutputDataSandbox storage.DataReference, currentState *arrayCore.State) (
 	newState *arrayCore.State, externalResources []*core.ExternalResource, err error) {
-	if int64(currentState.GetExecutionArraySize()) > config.MaxArrayJobSize {
-		ee := fmt.Errorf("array size > max allowed. Requested [%v]. Allowed [%v]", currentState.GetExecutionArraySize(), config.MaxArrayJobSize)
-		logger.Info(ctx, ee)
-		currentState = currentState.SetPhase(arrayCore.PhasePermanentFailure, 0).SetReason(ee.Error())
-		return currentState, externalResources, nil
-	}
 
 	newState = currentState
 	messageCollector := errorcollector.NewErrorMessageCollector()


### PR DESCRIPTION
# TL;DR
Map task cache lookups use background processes to perform datacatalog requests. This allows parallel execution for faster retrievals. In the case of large fanout map tasks the means that cache lookups may require multiple propeller rounds to complete. This means that the map task state will stay as "PhaseStart" and the data structures used to track subtask caching and phases are not initialized on the first round. With the current implementation, we attempt to use the cache lookup results to indicate cache status of subtasks on the PhaseStart round which can cause a panic in the scenario where the cache lookup has not yet completed and the subtask data structures have not yet been initialized. In this PR we wait to construct external resources (to notify the UI of subtask cache status and phase) until the map task cache lookup completes and we transition out of "PhaseStart".

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2786
fixes https://github.com/flyteorg/flyte/issues/2739

## Follow-up issue
_NA_
