### PR TITLE
Update hash algo to 64bit to reduce collisions

### DIFF
--- a/go/tasks/pluginmachinery/encoding/encoder.go
+++ b/go/tasks/pluginmachinery/encoding/encoder.go
@@ -12,10 +12,14 @@ const specialEncoderKey = "abcdefghijklmnopqrstuvwxyz123456"
 
 var Base32Encoder = base32.NewEncoding(specialEncoderKey).WithPadding(base32.NoPadding)
 
+// Algorithm defines an enum for the encoding algorithm to use.
 type Algorithm uint32
 
 const (
+	// Algorithm32 uses fnv32 bit encoder.
 	Algorithm32 Algorithm = iota
+
+	// Algorithm64 uses fnv64 bit encoder.
 	Algorithm64
 )
 
@@ -23,11 +27,13 @@ type Option interface {
 	option()
 }
 
+// AlgorithmOption defines a wrapper to pass the algorithm to encoding functions.
 type AlgorithmOption struct {
 	Option
 	algo Algorithm
 }
 
+// NewAlgorithmOption wraps the Algorithm into an AlgorithmOption to pass to the encoding functions.
 func NewAlgorithmOption(algo Algorithm) AlgorithmOption {
 	return AlgorithmOption{
 		algo: algo,

--- a/go/tasks/pluginmachinery/encoding/encoder.go
+++ b/go/tasks/pluginmachinery/encoding/encoder.go
@@ -21,6 +21,9 @@ const (
 
 	// Algorithm64 uses fnv64 bit encoder.
 	Algorithm64
+
+	// Algorithm128 uses fnv128 bit encoder.
+	Algorithm128
 )
 
 type Option interface {
@@ -55,6 +58,8 @@ func FixedLengthUniqueID(inputID string, maxLength int, options ...Option) (stri
 				hasher = fnv.New32a()
 			case Algorithm64:
 				hasher = fnv.New64a()
+			case Algorithm128:
+				hasher = fnv.New128a()
 			}
 		}
 	}

--- a/go/tasks/pluginmachinery/encoding/encoder.go
+++ b/go/tasks/pluginmachinery/encoding/encoder.go
@@ -75,7 +75,7 @@ func FixedLengthUniqueID(inputID string, maxLength int, options ...Option) (stri
 	// Encoding Length Calculation:
 	// Base32 Encoder will encode every 5 bits into an output character (2 ^ 5 = 32)
 	// output length = ciel(<input bits> / 5)
-	//	for 32a hashing	= ceil(32 / 5) = 7
+	//  for 32a hashing	= ceil(32 / 5) = 7
 	//  for 64a hashing	= ceil(64 / 5) = 13
 	// We prefix with character `f` so the final output is 8 or 14
 

--- a/go/tasks/pluginmachinery/encoding/encoder.go
+++ b/go/tasks/pluginmachinery/encoding/encoder.go
@@ -11,18 +11,25 @@ const specialEncoderKey = "abcdefghijklmnopqrstuvwxyz123456"
 
 var Base32Encoder = base32.NewEncoding(specialEncoderKey).WithPadding(base32.NoPadding)
 
-// Creates a new UniqueID that is based on the inputID and of a specified length, if the given id is longer than the
-// maxLength.
+// FixedLengthUniqueID creates a new UniqueID that is based on the inputID and of a specified length, if the given id is
+// longer than the maxLength.
 func FixedLengthUniqueID(inputID string, maxLength int) (string, error) {
 	if len(inputID) <= maxLength {
 		return inputID, nil
 	}
 
-	hasher := fnv.New32a()
-	// Using 32a an error can never happen, so this will always remain not covered by a unit test
+	hasher := fnv.New64a()
+	// Using 64a an error can never happen, so this will always remain not covered by a unit test
 	_, _ = hasher.Write([]byte(inputID)) // #nosec
+	// The maximum size of b is 64/8(bits) = 8 bytes
 	b := hasher.Sum(nil)
-	// expected length after this step is 8 chars (1 + 7 chars from Base32Encoder.EncodeToString(b))
+
+	// Encoding Length Calculation:
+	// Base32 Encoder will encode every 5 bits into an output character (2 ^ 5 = 32)
+	// output length = ciel(<input bits> / 5) = ceil(64 / 5) = 13
+	// We prefix with character `f` so the final output is 14
+
+	// expected length after this step is 14 chars (1 + 13 chars from Base32Encoder.EncodeToString(b))
 	finalStr := "f" + Base32Encoder.EncodeToString(b)
 	if len(finalStr) > maxLength {
 		return finalStr, fmt.Errorf("max Length is too small, cannot create an encoded string that is so small")
@@ -30,9 +37,9 @@ func FixedLengthUniqueID(inputID string, maxLength int) (string, error) {
 	return finalStr, nil
 }
 
-// Creates a new uniqueID using the parts concatenated using `-` and ensures that the uniqueID is not longer than the
-// maxLength. In case a simple concatenation yields a longer string, a new hashed ID is created which is always
-// around 8 characters in length
+// FixedLengthUniqueIDForParts creates a new uniqueID using the parts concatenated using `-` and ensures that the
+// uniqueID is not longer than the maxLength. In case a simple concatenation yields a longer string, a new hashed ID is
+// created which is always around 8 characters in length.
 func FixedLengthUniqueIDForParts(maxLength int, parts ...string) (string, error) {
 	b := strings.Builder{}
 	for i, p := range parts {

--- a/go/tasks/pluginmachinery/encoding/encoder_test.go
+++ b/go/tasks/pluginmachinery/encoding/encoder_test.go
@@ -1,6 +1,8 @@
 package encoding
 
 import (
+	"hash"
+	"hash/fnv"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,10 +17,10 @@ func TestFixedLengthUniqueID(t *testing.T) {
 		expectError bool
 	}{
 		{"smallerThanMax", "x", 5, "x", false},
-		{"veryLowLimit", "xx", 1, "flfryc2i", true},
-		{"highLimit", "xxxxxx", 5, "fufiti6i", true},
+		{"veryLowLimit", "xx", 1, "fbdyvab4vrxwm1", true},
+		{"highLimit", "xxxxxx", 5, "fsbykgqw4gv441", true},
 		{"higherLimit", "xxxxx", 10, "xxxxx", false},
-		{"largeID", "xxxxxxxxxxx", 10, "fggddjly", false},
+		{"largeID", "xxxxxxxxxxxxxxxxxxxxxxxx", 20, "fyuigwrqamd3yk", false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -28,7 +30,8 @@ func TestFixedLengthUniqueID(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, i, test.output)
+
+			assert.Equal(t, test.output, i)
 		})
 	}
 }
@@ -42,10 +45,10 @@ func TestFixedLengthUniqueIDForParts(t *testing.T) {
 		expectError bool
 	}{
 		{"smallerThanMax", []string{"x", "y", "z"}, 10, "x-y-z", false},
-		{"veryLowLimit", []string{"x", "y"}, 1, "fz2jizji", true},
+		{"veryLowLimit", []string{"x", "y"}, 1, "fx2llkgl6golek", true},
 		{"fittingID", []string{"x"}, 2, "x", false},
-		{"highLimit", []string{"x", "y", "z"}, 4, "fxzsoqrq", true},
-		{"largeID", []string{"x", "y", "z", "m", "n"}, 8, "fsigbmty", false},
+		{"highLimit", []string{"x", "y", "z"}, 4, "fvzirkr1kofp1m", true},
+		{"largeID", []string{"x", "y", "z", "m", "n", "y", "z", "m", "n", "y", "z", "m", "n"}, 15, "fwp4bky2kucex5", false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -55,7 +58,44 @@ func TestFixedLengthUniqueIDForParts(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, i, test.output)
+			assert.Equal(t, test.output, i)
 		})
 	}
+}
+
+func benchmarkKB(b *testing.B, h hash.Hash) {
+	b.SetBytes(1024)
+	data := make([]byte, 1024)
+	for i := range data {
+		data[i] = byte(i)
+	}
+
+	in := make([]byte, 0, h.Size())
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		h.Reset()
+		h.Write(data)
+		h.Sum(in)
+	}
+}
+
+// Documented Results:
+// goos: darwin
+// goarch: amd64
+// pkg: github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/encoding
+// cpu: Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz
+// BenchmarkFixedLengthUniqueID
+// BenchmarkFixedLengthUniqueID/New32a
+// BenchmarkFixedLengthUniqueID/New32a-16         	 1000000	      1088 ns/op	 941.25 MB/s
+// BenchmarkFixedLengthUniqueID/New64a
+// BenchmarkFixedLengthUniqueID/New64a-16         	 1239402	       951.3 ns/op	1076.39 MB/s
+func BenchmarkFixedLengthUniqueID(b *testing.B) {
+	b.Run("New32a", func(b *testing.B) {
+		benchmarkKB(b, fnv.New32a())
+	})
+
+	b.Run("New64a", func(b *testing.B) {
+		benchmarkKB(b, fnv.New64a())
+	})
 }

--- a/go/tasks/pluginmachinery/encoding/encoder_test.go
+++ b/go/tasks/pluginmachinery/encoding/encoder_test.go
@@ -51,6 +51,7 @@ func TestFixedLengthUniqueIDForParts(t *testing.T) {
 		{"highLimit", []string{"x", "y", "z"}, 4, Algorithm32, "fxzsoqrq", true},
 		{"largeID", []string{"x", "y", "z", "m", "n", "y", "z", "m", "n", "y", "z", "m", "n"}, 15, Algorithm32, "fe63sz6y", false},
 		{"largeID", []string{"x", "y", "z", "m", "n", "y", "z", "m", "n", "y", "z", "m", "n"}, 15, Algorithm64, "fwp4bky2kucex5", false},
+		{"largeID", []string{"x", "y", "z", "m", "n", "y", "z", "m", "n", "y", "z", "m", "n", "z", "m", "n", "y", "z", "m", "n"}, 30, Algorithm128, "fbmesl15enghpjepzjm5cp1zfqe", false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/go/tasks/pluginmachinery/encoding/encoder_test.go
+++ b/go/tasks/pluginmachinery/encoding/encoder_test.go
@@ -17,10 +17,10 @@ func TestFixedLengthUniqueID(t *testing.T) {
 		expectError bool
 	}{
 		{"smallerThanMax", "x", 5, "x", false},
-		{"veryLowLimit", "xx", 1, "fbdyvab4vrxwm1", true},
-		{"highLimit", "xxxxxx", 5, "fsbykgqw4gv441", true},
+		{"veryLowLimit", "xx", 1, "flfryc2i", true},
+		{"highLimit", "xxxxxx", 5, "fufiti6i", true},
 		{"higherLimit", "xxxxx", 10, "xxxxx", false},
-		{"largeID", "xxxxxxxxxxxxxxxxxxxxxxxx", 20, "fyuigwrqamd3yk", false},
+		{"largeID", "xxxxxxxxxxxxxxxxxxxxxxxx", 20, "fuaa3aji", false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -41,18 +41,20 @@ func TestFixedLengthUniqueIDForParts(t *testing.T) {
 		name        string
 		parts       []string
 		maxLength   int
+		algorithm   Algorithm
 		output      string
 		expectError bool
 	}{
-		{"smallerThanMax", []string{"x", "y", "z"}, 10, "x-y-z", false},
-		{"veryLowLimit", []string{"x", "y"}, 1, "fx2llkgl6golek", true},
-		{"fittingID", []string{"x"}, 2, "x", false},
-		{"highLimit", []string{"x", "y", "z"}, 4, "fvzirkr1kofp1m", true},
-		{"largeID", []string{"x", "y", "z", "m", "n", "y", "z", "m", "n", "y", "z", "m", "n"}, 15, "fwp4bky2kucex5", false},
+		{"smallerThanMax", []string{"x", "y", "z"}, 10, Algorithm32, "x-y-z", false},
+		{"veryLowLimit", []string{"x", "y"}, 1, Algorithm32, "fz2jizji", true},
+		{"fittingID", []string{"x"}, 2, Algorithm32, "x", false},
+		{"highLimit", []string{"x", "y", "z"}, 4, Algorithm32, "fxzsoqrq", true},
+		{"largeID", []string{"x", "y", "z", "m", "n", "y", "z", "m", "n", "y", "z", "m", "n"}, 15, Algorithm32, "fe63sz6y", false},
+		{"largeID", []string{"x", "y", "z", "m", "n", "y", "z", "m", "n", "y", "z", "m", "n"}, 15, Algorithm64, "fwp4bky2kucex5", false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			i, err := FixedLengthUniqueIDForParts(test.maxLength, test.parts)
+			i, err := FixedLengthUniqueIDForParts(test.maxLength, test.parts, NewAlgorithmOption(test.algorithm))
 			if test.expectError {
 				assert.Error(t, err)
 			} else {

--- a/go/tasks/pluginmachinery/encoding/encoder_test.go
+++ b/go/tasks/pluginmachinery/encoding/encoder_test.go
@@ -52,7 +52,7 @@ func TestFixedLengthUniqueIDForParts(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			i, err := FixedLengthUniqueIDForParts(test.maxLength, test.parts...)
+			i, err := FixedLengthUniqueIDForParts(test.maxLength, test.parts)
 			if test.expectError {
 				assert.Error(t, err)
 			} else {


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
We use 64bit fnv hashing to shorten the execution id lengths, however that has lead to collisions due to its low entropy. Bumping it to 64bit to reduce such collisions.

- [x] Figure out how to rollout the change without affecting in-flight executions.

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2778
