### PR TITLE
Update k8s array system retries max value

### DIFF
--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -107,7 +107,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 	// interruptible subtasks.
 	if len(currentState.SystemFailures.GetItems()) == 0 {
 		count := uint(currentState.GetExecutionArraySize())
-		maxValue := bitarray.Item(tCtx.TaskExecutionMetadata().GetInterruptibleFailureThreshold())
+		maxValue := bitarray.Item(tCtx.TaskExecutionMetadata().GetMaxAttempts())
 
 		systemFailuresArray, err := bitarray.NewCompactArray(count, maxValue)
 		if err != nil {


### PR DESCRIPTION
# TL;DR
Currently the k8s array plugin uses the interruptible threshold for the maximum value in the bitarray tracking system failures for map task subtasks. If the bitarray attempts to store a value over it's maximum configured value it results in a panic (rather than throwing an error). Therefore, a panic may occur if the number of system retries exceeds the interruptible threshold. This PR uses the maximum number of retries as the maximum value in the system retries bitarray and therefore fixes the panic.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/2788

## Follow-up issue
_NA_
