### PR TITLE
Update snowflake endpoints

### DIFF
--- a/go/tasks/plugins/webapi/snowflake/integration_test.go
+++ b/go/tasks/plugins/webapi/snowflake/integration_test.go
@@ -65,7 +65,7 @@ func TestEndToEnd(t *testing.T) {
 func newFakeSnowflakeServer() *httptest.Server {
 	statementHandle := "019e7546-0000-278c-0000-40f10001a082"
 	return httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.URL.Path == "/api/statements" && request.Method == "POST" {
+		if request.URL.Path == "/api/v2/statements" && request.Method == "POST" {
 			writer.WriteHeader(202)
 			bytes := []byte(fmt.Sprintf(`{
 			  "statementHandle": "%v",
@@ -75,7 +75,7 @@ func newFakeSnowflakeServer() *httptest.Server {
 			return
 		}
 
-		if request.URL.Path == "/api/statements/"+statementHandle && request.Method == "GET" {
+		if request.URL.Path == "/api/v2/statements/"+statementHandle && request.Method == "GET" {
 			writer.WriteHeader(200)
 			bytes := []byte(fmt.Sprintf(`{
 			  "statementHandle": "%v",
@@ -85,7 +85,7 @@ func newFakeSnowflakeServer() *httptest.Server {
 			return
 		}
 
-		if request.URL.Path == "/api/statements/"+statementHandle+"/cancel" && request.Method == "POST" {
+		if request.URL.Path == "/api/v2/statements/"+statementHandle+"/cancel" && request.Method == "POST" {
 			writer.WriteHeader(200)
 			return
 		}

--- a/go/tasks/plugins/webapi/snowflake/plugin.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin.go
@@ -207,14 +207,14 @@ func buildRequest(method string, queryInfo QueryInfo, snowflakeEndpoint string, 
 	var snowflakeURL string
 	// for mocking/testing purposes
 	if snowflakeEndpoint == "" {
-		snowflakeURL = "https://" + account + ".snowflakecomputing.com/api/v2/statements"
+		snowflakeURL = "https://" + account + ".snowflakecomputing.com/api/v2"
 	} else {
-		snowflakeURL = snowflakeEndpoint + "/api/v2/statements"
+		snowflakeURL = snowflakeEndpoint + "/api/v2"
 	}
 
 	var data []byte
 	if method == post && !isCancel {
-		snowflakeURL += "?async=true"
+		snowflakeURL += "/statements?async=true"
 		data = []byte(fmt.Sprintf(`{
 		  "statement": "%v",
 		  "database": "%v",

--- a/go/tasks/plugins/webapi/snowflake/plugin.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin.go
@@ -167,9 +167,6 @@ func (p Plugin) Get(ctx context.Context, taskCtx webapi.GetContext) (latest weba
 }
 
 func (p Plugin) Delete(ctx context.Context, taskCtx webapi.DeleteContext) error {
-	if taskCtx.ResourceMeta() == nil {
-		return nil
-	}
 	exec := taskCtx.ResourceMeta().(*ResourceMetaWrapper)
 	req, err := buildRequest(post, QueryInfo{}, p.cfg.snowflakeEndpoint,
 		exec.Account, exec.Token, exec.QueryID, true)

--- a/go/tasks/plugins/webapi/snowflake/plugin.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin.go
@@ -207,14 +207,14 @@ func buildRequest(method string, queryInfo QueryInfo, snowflakeEndpoint string, 
 	var snowflakeURL string
 	// for mocking/testing purposes
 	if snowflakeEndpoint == "" {
-		snowflakeURL = "https://" + account + ".snowflakecomputing.com/api/v2"
+		snowflakeURL = "https://" + account + ".snowflakecomputing.com/api/v2/statements"
 	} else {
-		snowflakeURL = snowflakeEndpoint + "/api/v2"
+		snowflakeURL = snowflakeEndpoint + "/api/v2/statements"
 	}
 
 	var data []byte
 	if method == post && !isCancel {
-		snowflakeURL += "/statements?async=true"
+		snowflakeURL += "?async=true"
 		data = []byte(fmt.Sprintf(`{
 		  "statement": "%v",
 		  "database": "%v",

--- a/go/tasks/plugins/webapi/snowflake/plugin.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin.go
@@ -167,6 +167,9 @@ func (p Plugin) Get(ctx context.Context, taskCtx webapi.GetContext) (latest weba
 }
 
 func (p Plugin) Delete(ctx context.Context, taskCtx webapi.DeleteContext) error {
+	if taskCtx.ResourceMeta() == nil {
+		return nil
+	}
 	exec := taskCtx.ResourceMeta().(*ResourceMetaWrapper)
 	req, err := buildRequest(post, QueryInfo{}, p.cfg.snowflakeEndpoint,
 		exec.Account, exec.Token, exec.QueryID, true)

--- a/go/tasks/plugins/webapi/snowflake/plugin.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin.go
@@ -207,7 +207,7 @@ func buildRequest(method string, queryInfo QueryInfo, snowflakeEndpoint string, 
 	var snowflakeURL string
 	// for mocking/testing purposes
 	if snowflakeEndpoint == "" {
-		snowflakeURL = "https://" + account + ".snowflakecomputing.com/api/statements"
+		snowflakeURL = "https://" + account + ".snowflakecomputing.com/api/v2/statements"
 	} else {
 		snowflakeURL = snowflakeEndpoint + "/api/v2/statements"
 	}

--- a/go/tasks/plugins/webapi/snowflake/plugin.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin.go
@@ -209,7 +209,7 @@ func buildRequest(method string, queryInfo QueryInfo, snowflakeEndpoint string, 
 	if snowflakeEndpoint == "" {
 		snowflakeURL = "https://" + account + ".snowflakecomputing.com/api/statements"
 	} else {
-		snowflakeURL = snowflakeEndpoint + "/api/statements"
+		snowflakeURL = snowflakeEndpoint + "/api/v2/statements"
 	}
 
 	var data []byte

--- a/go/tasks/plugins/webapi/snowflake/plugin_test.go
+++ b/go/tasks/plugins/webapi/snowflake/plugin_test.go
@@ -66,7 +66,7 @@ func TestBuildRequest(t *testing.T) {
 	token := "test-token"
 	queryID := "019e70eb-0000-278b-0000-40f100012b1a"
 	snowflakeEndpoint := ""
-	snowflakeURL := "https://" + account + ".snowflakecomputing.com/api/statements"
+	snowflakeURL := "https://" + account + ".snowflakecomputing.com/api/v2/statements"
 	t.Run("build http request for submitting a snowflake query", func(t *testing.T) {
 		queryInfo := QueryInfo{
 			Account:   account,


### PR DESCRIPTION
# TL;DR
Snowflake has updated their API endpoint to [api/v2/statements](https://docs.snowflake.com/en/developer-guide/sql-api/reference.html#snowflake-sql-api-reference), so we should update the endpoint in the snowflake plugin.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
NA

## Follow-up issue
_NA_
