### PR TITLE
Added '-unknown' to container name for Lyft log ingestion

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.0.0
 	github.com/aws/aws-sdk-go-v2/service/athena v1.0.0
 	github.com/coocood/freecache v1.1.1
-	github.com/flyteorg/flyteidl v0.21.0
+	github.com/flyteorg/flyteidl v0.21.6
 	github.com/flyteorg/flytestdlib v0.3.36
 	github.com/go-logr/zapr v0.4.0 // indirect
 	github.com/go-test/deep v1.0.7

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
-github.com/flyteorg/flyteidl v0.21.0 h1:AwHNusfxJMfRRSDk2QWfb3aIlyLJrFWVGtpXCbCtJ5A=
-github.com/flyteorg/flyteidl v0.21.0/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
+github.com/flyteorg/flyteidl v0.21.6 h1:0GK5QB0I/MGof9dXl9kW6LTzBYklQWthPOL0e4iAQbg=
+github.com/flyteorg/flyteidl v0.21.6/go.mod h1:576W2ViEyjTpT+kEVHAGbrTP3HARNUZ/eCwrNPmdx9U=
 github.com/flyteorg/flytestdlib v0.3.13/go.mod h1:Tz8JCECAbX6VWGwFT6cmEQ+RJpZ/6L9pswu3fzWs220=
 github.com/flyteorg/flytestdlib v0.3.36 h1:XLvc7kfc9XkQBpPvNXevh5+Ijbgmd7gEOHTWhdEY5eA=
 github.com/flyteorg/flytestdlib v0.3.36/go.mod h1:7cDWkY3v7xsoesFcDdu6DSW5Q2U2W5KlHUbUHSwBG1Q=

--- a/go/tasks/config_load_test.go
+++ b/go/tasks/config_load_test.go
@@ -73,6 +73,11 @@ func TestLoadConfig(t *testing.T) {
 		assert.Equal(t, map[string]string{"x/interruptible": "true"}, k8sConfig.InterruptibleNodeSelector)
 		assert.Equal(t, "x/flyte", k8sConfig.InterruptibleTolerations[0].Key)
 		assert.Equal(t, "interruptible", k8sConfig.InterruptibleTolerations[0].Value)
+		assert.Contains(t, k8sConfig.ArchitectureNodeSelector, "amd64")
+		assert.Equal(t, map[string]string{"x/architecture": "amd64"}, k8sConfig.ArchitectureNodeSelector["amd64"])
+		assert.Contains(t, k8sConfig.ArchitectureTolerations, "amd64")
+		assert.Equal(t, "x/flyte", k8sConfig.ArchitectureTolerations["amd64"][0].Key)
+		assert.Equal(t, "amd64", k8sConfig.ArchitectureTolerations["amd64"][0].Value)
 	})
 
 	t.Run("logs-config-test", func(t *testing.T) {

--- a/go/tasks/pluginmachinery/flytek8s/config/config.go
+++ b/go/tasks/pluginmachinery/flytek8s/config/config.go
@@ -85,7 +85,7 @@ type K8sPluginConfig struct {
 	SchedulerName string `json:"scheduler-name" pflag:",Defines scheduler name."`
 
 	// -----------------------------------------------------------------
-	// Special tolerations and node selector for Interruptible tasks. This allows scheduling interruptible tasks onto specific hardward
+	// Special tolerations and node selector for Interruptible tasks. This allows scheduling interruptible tasks onto specific hardware
 
 	// Tolerations for interruptible k8s pods: These tolerations are added to the pods that can tolerate getting evicted from a node. We
 	// can leverage this for better bin-packing and using low-reliability cheaper machines.
@@ -98,6 +98,19 @@ type K8sPluginConfig struct {
 	// pods respectively
 	InterruptibleNodeSelectorRequirement    *v1.NodeSelectorRequirement `json:"interruptible-node-selector-requirement" pflag:"-,Node selector requirement to add to interruptible pods"`
 	NonInterruptibleNodeSelectorRequirement *v1.NodeSelectorRequirement `json:"non-interruptible-node-selector-requirement" pflag:"-,Node selector requirement to add to non-interruptible pods"`
+
+	// -----------------------------------------------------------------
+	// Special tolerations and node selector for different architecture. This allows scheduling tasks onto specific hardware
+
+	// Tolerations for the architecture of k8s pods: These tolerations are added to the pods that specify a specific architecture.
+	ArchitectureTolerations map[string][]v1.Toleration `json:"architecture-tolerations"  pflag:"-,Tolerations to be applied for a specific architecture"`
+	// Node Selector Labels for interruptible pods: Similar to ArchitectureTolerations, these node selector labels are added for pods that need a specific
+	// architecture.
+	// Deprecated: Please use InterruptibleNodeSelectorRequirement/NonInterruptibleNodeSelectorRequirement
+	ArchitectureNodeSelector map[string]map[string]string `json:"architecture-node-selector" pflag:"-,Defines a set of node selector labels to select architecture."`
+	// Node Selector Requirements to be added for specific architecture
+	// pods respectively
+	ArchitectureNodeSelectorRequirement map[string]*v1.NodeSelectorRequirement `json:"architecture-node-selector-requirement" pflag:"-,Node selector requirement to add for specific architecture"`
 
 	// ----------------------------------------------------------------------
 	// Specific tolerations that are added for certain resources. Useful for maintaining gpu resources separate in the cluster

--- a/go/tasks/pluginmachinery/flytek8s/container_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper.go
@@ -117,7 +117,7 @@ func ToK8sContainer(ctx context.Context, taskContainer *core.Container, iFace *c
 	}
 	// Make the container name the same as the pod name, unless it violates K8s naming conventions
 	// Container names are subject to the DNS-1123 standard
-	containerName := parameters.TaskExecMetadata.GetTaskExecutionID().GetGeneratedName()
+	containerName := parameters.TaskExecMetadata.GetTaskExecutionID().GetGeneratedName() + "-unknown"
 	if errs := validation.IsDNS1123Label(containerName); len(errs) > 0 {
 		containerName = rand.String(4)
 	}

--- a/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
+++ b/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"os"
 	"strconv"
+	"strings"
 
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s/config"
 
 	"github.com/flyteorg/flytestdlib/contextutils"
@@ -130,7 +132,7 @@ func DecorateEnvVars(ctx context.Context, envVars []v1.EnvVar, id pluginsCore.Ta
 	return envVars
 }
 
-func GetPodTolerations(interruptible bool, resourceRequirements ...v1.ResourceRequirements) []v1.Toleration {
+func GetPodTolerations(interruptible bool, architecture core.Container_Architecture, resourceRequirements ...v1.ResourceRequirements) []v1.Toleration {
 	// 1. Get the tolerations for the resources requested
 	var tolerations []v1.Toleration
 	resourceNames := sets.NewString()
@@ -155,7 +157,12 @@ func GetPodTolerations(interruptible bool, resourceRequirements ...v1.ResourceRe
 		tolerations = append(tolerations, config.GetK8sPluginConfig().InterruptibleTolerations...)
 	}
 
-	// 3. Add default tolerations
+	// 3. Get the tolerations for the specific architecture
+	if architecture != core.Container_UNKNOWN {
+		tolerations = append(tolerations, config.GetK8sPluginConfig().ArchitectureTolerations[strings.ToLower(architecture.String())]...)
+	}
+
+	// 4. Add default tolerations
 	tolerations = append(tolerations, config.GetK8sPluginConfig().DefaultTolerations...)
 
 	return tolerations

--- a/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds_test.go
@@ -186,7 +186,7 @@ func TestGetTolerationsForResources(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.NoError(t, config.SetK8sPluginConfig(&config.K8sPluginConfig{ResourceTolerations: tt.setVal, DefaultTolerations: tt.setDefaults}))
-			if got := GetPodTolerations(true, tt.args.resources); len(got) != len(tt.want) {
+			if got := GetPodTolerations(true, core.Container_UNKNOWN, tt.args.resources); len(got) != len(tt.want) {
 				t.Errorf("GetPodTolerations() = %v, want %v", got, tt.want)
 			} else {
 				for _, tol := range tt.want {

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -518,7 +518,7 @@ func TestToK8sPod(t *testing.T) {
 		p, err := ToK8sPodSpec(ctx, x)
 		assert.NoError(t, err)
 		assert.Equal(t, len(p.Tolerations), 0)
-		assert.Equal(t, "some-acceptable-name", p.Containers[0].Name)
+		assert.Equal(t, "some-acceptable-name-unknown", p.Containers[0].Name)
 	})
 
 	t.Run("Default toleration, selector, scheduler", func(t *testing.T) {
@@ -553,7 +553,7 @@ func TestToK8sPod(t *testing.T) {
 		assert.Equal(t, 1, len(p.Tolerations))
 		assert.Equal(t, 1, len(p.NodeSelector))
 		assert.Equal(t, "myScheduler", p.SchedulerName)
-		assert.Equal(t, "some-acceptable-name", p.Containers[0].Name)
+		assert.Equal(t, "some-acceptable-name-unknown", p.Containers[0].Name)
 	})
 }
 

--- a/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
+++ b/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
@@ -40,6 +40,57 @@ plugins:
     non-interruptible-node-selector-requirement:
       key:  x/interruptible
       operator: DoesNotExist
+    architecture-node-selector:
+      amd64:
+        - x/architecture: "amd64"
+      arm64:
+        - x/architecture: "arm64"
+      armv6:
+        - x/architecture: "armv6"
+      armv7:
+        - x/architecture: "armv7"
+    architecture-tolerations:
+      amd64:
+        - key: x/flyte
+          value: amd64
+          operator: Equal
+          effect: NoSchedule
+      arm64:
+        - key: x/flyte
+          value: arm64
+          operator: Equal
+          effect: NoSchedule
+      armv6:
+        - key: x/flyte
+          value: armv6
+          operator: Equal
+          effect: NoSchedule
+      armv7:
+        - key: x/flyte
+          value: armv7
+          operator: Equal
+          effect: NoSchedule
+    architecture-node-selector-requirement:
+      amd64:
+        key: x/architecture
+        operator: In
+        values:
+          - "amd64"
+      arm64:
+        key: x/architecture
+        operator: In
+        values:
+          - "arm64"
+      armv6:
+        key: x/architecture
+        operator: In
+        values:
+          - "armv6"
+      armv7:
+        key: x/architecture
+        operator: In
+        values:
+          - "armv7"
     default-env-vars:
       - AWS_METADATA_SERVICE_TIMEOUT: 5
       - AWS_METADATA_SERVICE_NUM_ATTEMPTS: 20

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -220,9 +220,9 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 	// Add Architecture Tolerations/NodeSelector to all pods
 	if taskTemplate.GetContainer().GetArchitecture() != core.Container_UNKNOWN {
 		j.Spec.Driver.NodeSelector = config.GetK8sPluginConfig().ArchitectureNodeSelector[strings.ToLower(taskTemplate.GetContainer().GetArchitecture().String())]
-		j.Spec.Driver.Tolerations = config.GetK8sPluginConfig().ArchitectureTolerations[strings.ToLower(taskTemplate.GetContainer().GetArchitecture().String())]
+		j.Spec.Driver.SparkPodSpec.Tolerations = config.GetK8sPluginConfig().ArchitectureTolerations[strings.ToLower(taskTemplate.GetContainer().GetArchitecture().String())]
 		j.Spec.Executor.NodeSelector = config.GetK8sPluginConfig().ArchitectureNodeSelector[strings.ToLower(taskTemplate.GetContainer().GetArchitecture().String())]
-		j.Spec.Executor.Tolerations = config.GetK8sPluginConfig().ArchitectureTolerations[strings.ToLower(taskTemplate.GetContainer().GetArchitecture().String())]
+		j.Spec.Executor.SparkPodSpec.Tolerations = config.GetK8sPluginConfig().ArchitectureTolerations[strings.ToLower(taskTemplate.GetContainer().GetArchitecture().String())]
 		if taskTemplate.GetContainer().GetArchitecture() == core.Container_ARM64 {
 			j.Spec.SparkConf["spark.kubernetes.node.selector.beta.kubernetes.io/arch"] = "arm64"
 		}
@@ -230,7 +230,7 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 
 	// Add Tolerations/NodeSelector to only Executor pods.
 	if taskCtx.TaskExecutionMetadata().IsInterruptible() {
-		j.Spec.Executor.Tolerations = append(j.Spec.Executor.Tolerations, config.GetK8sPluginConfig().InterruptibleTolerations...)
+		j.Spec.Executor.SparkPodSpec.Tolerations = append(j.Spec.Executor.SparkPodSpec.Tolerations, config.GetK8sPluginConfig().InterruptibleTolerations...)
 		j.Spec.Executor.NodeSelector = utils.UnionMaps(j.Spec.Executor.NodeSelector, config.GetK8sPluginConfig().InterruptibleNodeSelector)
 	}
 

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -217,11 +217,23 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 		j.Spec.MainClass = &sparkJob.MainClass
 	}
 
+	// Add Architecture Tolerations/NodeSelector to all pods
+	if taskTemplate.GetContainer().GetArchitecture() != core.Container_UNKNOWN {
+		j.Spec.Driver.NodeSelector = config.GetK8sPluginConfig().ArchitectureNodeSelector[strings.ToLower(taskTemplate.GetContainer().GetArchitecture().String())]
+		j.Spec.Driver.Tolerations = config.GetK8sPluginConfig().ArchitectureTolerations[strings.ToLower(taskTemplate.GetContainer().GetArchitecture().String())]
+		j.Spec.Executor.NodeSelector = config.GetK8sPluginConfig().ArchitectureNodeSelector[strings.ToLower(taskTemplate.GetContainer().GetArchitecture().String())]
+		j.Spec.Executor.Tolerations = config.GetK8sPluginConfig().ArchitectureTolerations[strings.ToLower(taskTemplate.GetContainer().GetArchitecture().String())]
+		if taskTemplate.GetContainer().GetArchitecture() == core.Container_ARM64 {
+			j.Spec.SparkConf["spark.kubernetes.node.selector.beta.kubernetes.io/arch"] = "arm64"
+		}
+	}
+
 	// Add Tolerations/NodeSelector to only Executor pods.
 	if taskCtx.TaskExecutionMetadata().IsInterruptible() {
-		j.Spec.Executor.Tolerations = config.GetK8sPluginConfig().InterruptibleTolerations
-		j.Spec.Executor.NodeSelector = config.GetK8sPluginConfig().InterruptibleNodeSelector
+		j.Spec.Executor.Tolerations = append(j.Spec.Executor.SparkPodSpec.Tolerations, config.GetK8sPluginConfig().InterruptibleTolerations...)
+		j.Spec.Executor.NodeSelector = utils.UnionMaps(j.Spec.Executor.SparkPodSpec.NodeSelector, config.GetK8sPluginConfig().InterruptibleNodeSelector)
 	}
+
 	return j, nil
 }
 

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -230,8 +230,8 @@ func (sparkResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsCo
 
 	// Add Tolerations/NodeSelector to only Executor pods.
 	if taskCtx.TaskExecutionMetadata().IsInterruptible() {
-		j.Spec.Executor.Tolerations = append(j.Spec.Executor.SparkPodSpec.Tolerations, config.GetK8sPluginConfig().InterruptibleTolerations...)
-		j.Spec.Executor.NodeSelector = utils.UnionMaps(j.Spec.Executor.SparkPodSpec.NodeSelector, config.GetK8sPluginConfig().InterruptibleNodeSelector)
+		j.Spec.Executor.Tolerations = append(j.Spec.Executor.Tolerations, config.GetK8sPluginConfig().InterruptibleTolerations...)
+		j.Spec.Executor.NodeSelector = utils.UnionMaps(j.Spec.Executor.NodeSelector, config.GetK8sPluginConfig().InterruptibleNodeSelector)
 	}
 
 	return j, nil

--- a/go/tasks/testdata/config.yaml
+++ b/go/tasks/testdata/config.yaml
@@ -44,6 +44,36 @@ plugins:
         value: interruptible
         operator: Equal
         effect: NoSchedule
+    architecture-node-selector:
+      amd64:
+        - x/architecture: "amd64"
+      arm64:
+        - x/architecture: "arm64"
+      armv6:
+        - x/architecture: "armv6"
+      armv7:
+        - x/architecture: "armv7"
+    architecture-tolerations:
+      amd64:
+        - key: x/flyte
+          value: amd64
+          operator: Equal
+          effect: NoSchedule
+      arm64:
+        - key: x/flyte
+          value: arm64
+          operator: Equal
+          effect: NoSchedule
+      armv6:
+        - key: x/flyte
+          value: armv6
+          operator: Equal
+          effect: NoSchedule
+      armv7:
+        - key: x/flyte
+          value: armv7
+          operator: Equal
+          effect: NoSchedule
     default-env-vars:
       - AWS_METADATA_SERVICE_TIMEOUT: 5
       - AWS_METADATA_SERVICE_NUM_ATTEMPTS: 20


### PR DESCRIPTION
# TL;DR
Adding `-unknown` suffix to container name for Lyft logging agent to detect and send logs to logging pipeline.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin