### PR TITLE
Added -unknown suffix to container name

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/container_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper.go
@@ -117,7 +117,7 @@ func ToK8sContainer(ctx context.Context, taskContainer *core.Container, iFace *c
 	}
 	// Make the container name the same as the pod name, unless it violates K8s naming conventions
 	// Container names are subject to the DNS-1123 standard
-	containerName := parameters.TaskExecMetadata.GetTaskExecutionID().GetGeneratedName()
+	containerName := parameters.TaskExecMetadata.GetTaskExecutionID().GetGeneratedName() + "-unknown"
 	if errs := validation.IsDNS1123Label(containerName); len(errs) > 0 {
 		containerName = rand.String(4)
 	}

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -518,7 +518,7 @@ func TestToK8sPod(t *testing.T) {
 		p, err := ToK8sPodSpec(ctx, x)
 		assert.NoError(t, err)
 		assert.Equal(t, len(p.Tolerations), 0)
-		assert.Equal(t, "some-acceptable-name", p.Containers[0].Name)
+		assert.Equal(t, "some-acceptable-name-unknown", p.Containers[0].Name)
 	})
 
 	t.Run("Default toleration, selector, scheduler", func(t *testing.T) {
@@ -553,7 +553,7 @@ func TestToK8sPod(t *testing.T) {
 		assert.Equal(t, 1, len(p.Tolerations))
 		assert.Equal(t, 1, len(p.NodeSelector))
 		assert.Equal(t, "myScheduler", p.SchedulerName)
-		assert.Equal(t, "some-acceptable-name", p.Containers[0].Name)
+		assert.Equal(t, "some-acceptable-name-unknown", p.Containers[0].Name)
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Jason Carey <jcarey@lyft.com>

# TL;DR
Adding -unknown suffix to container name for Lyft logging agent to detect and send logs to logging pipeline.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin
