### PR TITLE
added 'python-task' to registered task types for pod plugin

### DIFF
--- a/go/tasks/plugins/k8s/pod/container.go
+++ b/go/tasks/plugins/k8s/pod/container.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	ContainerTaskType = "container"
+	PythonTaskType    = "python-task"
 )
 
 type containerPodBuilder struct {

--- a/go/tasks/plugins/k8s/pod/plugin.go
+++ b/go/tasks/plugins/k8s/pod/plugin.go
@@ -157,7 +157,7 @@ func init() {
 	pluginmachinery.PluginRegistry().RegisterK8sPlugin(
 		k8s.PluginEntry{
 			ID:                  ContainerTaskType,
-			RegisteredTaskTypes: []pluginsCore.TaskType{ContainerTaskType},
+			RegisteredTaskTypes: []pluginsCore.TaskType{ContainerTaskType, PythonTaskType},
 			ResourceToWatch:     &v1.Pod{},
 			Plugin:              DefaultPodPlugin,
 			IsDefault:           true,
@@ -176,7 +176,7 @@ func init() {
 	pluginmachinery.PluginRegistry().RegisterK8sPlugin(
 		k8s.PluginEntry{
 			ID:                  podTaskType,
-			RegisteredTaskTypes: []pluginsCore.TaskType{ContainerTaskType, SidecarTaskType},
+			RegisteredTaskTypes: []pluginsCore.TaskType{ContainerTaskType, PythonTaskType, SidecarTaskType},
 			ResourceToWatch:     &v1.Pod{},
 			Plugin:              DefaultPodPlugin,
 			IsDefault:           true,


### PR DESCRIPTION
# TL;DR
Python tasks are annotated with "python-task" for the task type. In FlytePlugins we do not have a Handler that registers with that task type, so in every case it falls back to the container handler which is registered as the default for everything that does not match an existing handler. However, this results in log messages like `No plugin found for Handler-type [python-task], defaulting to [container]` everytime that propeller evaluates a "python-task" node. This can result in a very large number of unuseful log messages, effectively reducing the utility of logging. Adding "python-task" as a registered type will remove this message from the logs.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
