### PR TITLE
Attempt to decorate k8 resource manual deletion with message

### DIFF
--- a/go/tasks/plugins/array/k8s/subtask.go
+++ b/go/tasks/plugins/array/k8s/subtask.go
@@ -315,7 +315,8 @@ func getSubtaskPhaseInfo(ctx context.Context, stCtx SubTaskExecutionContext, cfg
 		// the node are marked with a deletionTimestamp, but our finalizers prevent the pod from being deleted.
 		// This can also happen when a user deletes a Pod directly.
 		err := kubeClient.GetClient().Get(ctx, nsName, pod)
-		failureReason := fmt.Sprintf("object [%s] terminated in the background, manually. reason: %s", nsName.String(), err.Error())
+		freason := k8serrors.ReasonForError(err)
+		failureReason := fmt.Sprintf("object [%s] terminated in the background, manually due to reason: %s", nsName.String(), freason.String())
 		return pluginsCore.PhaseInfoSystemRetryableFailure("UnexpectedObjectDeletion", failureReason, nil), nil
 	}
 

--- a/go/tasks/plugins/array/k8s/subtask.go
+++ b/go/tasks/plugins/array/k8s/subtask.go
@@ -314,9 +314,7 @@ func getSubtaskPhaseInfo(ctx context.Context, stCtx SubTaskExecutionContext, cfg
 		// mark the task as a retryable failure.  We've seen this happen when a kubelet disappears - all pods running on
 		// the node are marked with a deletionTimestamp, but our finalizers prevent the pod from being deleted.
 		// This can also happen when a user deletes a Pod directly.
-		err := kubeClient.GetClient().Get(ctx, nsName, pod)
-		freason := k8serrors.ReasonForError(err)
-		failureReason := fmt.Sprintf("object [%s] terminated in the background, manually due to reason: %s", nsName.String(), freason.String())
+		failureReason := fmt.Sprintf("object [%s] terminated in the background, manually due to reason: %s with the message: %s", nsName.String(), pod.Status.Reason, pod.Status.Message)
 		return pluginsCore.PhaseInfoSystemRetryableFailure("UnexpectedObjectDeletion", failureReason, nil), nil
 	}
 

--- a/go/tasks/plugins/array/k8s/subtask.go
+++ b/go/tasks/plugins/array/k8s/subtask.go
@@ -314,7 +314,8 @@ func getSubtaskPhaseInfo(ctx context.Context, stCtx SubTaskExecutionContext, cfg
 		// mark the task as a retryable failure.  We've seen this happen when a kubelet disappears - all pods running on
 		// the node are marked with a deletionTimestamp, but our finalizers prevent the pod from being deleted.
 		// This can also happen when a user deletes a Pod directly.
-		failureReason := fmt.Sprintf("object [%s] terminated in the background, manually", nsName.String())
+		err := kubeClient.GetClient().Get(ctx, nsName, pod)
+		failureReason := fmt.Sprintf("object [%s] terminated in the background, manually. reason: %s", nsName.String(), err.Error())
 		return pluginsCore.PhaseInfoSystemRetryableFailure("UnexpectedObjectDeletion", failureReason, nil), nil
 	}
 


### PR DESCRIPTION
# TL;DR
This is an attempt to provide a reason for the pod failure when the resources are manually deleted.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This is just an attempt to provide a reason for pod failure when the k8 resources are deleted manually, I am unsure about this fix. I used the **k8serrors.ReasonForError()** to get the reason for pod failure and then attached it to the object that failed. Check [line 317](https://github.com/Ln11211/flyteplugins/blob/ceee0fa0a881ec2a394b03fe2fe5ebad8b36022c/go/tasks/plugins/array/k8s/subtask.go#L317) and 318.

## Tracking Issue
Issue [#2843](https://github.com/flyteorg/flyte/issues/2843)