### PR TITLE
Ignore codecov upload failures

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Unit Tests
         run: make install && make test_unit_codecov
       - name: Push CodeCov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: coverage.txt
           flags: unittests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -60,6 +60,6 @@ jobs:
         with:
           file: coverage.txt
           flags: unittests
-          fail_ci_if_error: true
+          fail_ci_if_error: false
       - name: Lint
         run: make install && make lint

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           file: coverage.txt
           flags: unittests
-          fail_ci_if_error: true
+          fail_ci_if_error: false
       - name: Lint
         run: make install && make lint
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Unit Tests
         run: make install && make test_unit_codecov
       - name: Push CodeCov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3.1.1
         with:
           file: coverage.txt
           flags: unittests


### PR DESCRIPTION
# TL;DR
This PR allows the github worklow to succeed even if codecov upload fails.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
