### PR TITLE
Fix error message when output file is too large to read

### DIFF
--- a/go/tasks/pluginmachinery/ioutils/remote_file_output_reader.go
+++ b/go/tasks/pluginmachinery/ioutils/remote_file_output_reader.go
@@ -82,7 +82,7 @@ func (r RemoteFileOutputReader) Exists(ctx context.Context) (bool, error) {
 	}
 	if md.Exists() {
 		if md.Size() > r.maxPayloadSize {
-			return false, errors.Errorf("error file @[%s] is too large [%d] bytes, max allowed [%d] bytes", r.outPath.GetErrorPath(), md.Size(), r.maxPayloadSize)
+			return false, errors.Errorf("output file @[%s] is too large [%d] bytes, max allowed [%d] bytes", r.outPath.GetOutputPath(), md.Size(), r.maxPayloadSize)
 		}
 		return true, nil
 	}


### PR DESCRIPTION
Signed-off-by: Haytham Abuelfutuh <haytham@afutuh.com>

# TL;DR
Fixing copy/paste error for the error message returned when an output vs error file is too large

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Tracking Issue

fixes https://github.com/flyteorg/flyte/issues/3082