### PR TITLE
sending correct external resources for k8s-array plugin

### DIFF
--- a/go/tasks/plugins/array/awsbatch/executor.go
+++ b/go/tasks/plugins/array/awsbatch/executor.go
@@ -88,10 +88,12 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		pluginState.State, err = array.AssembleFinalOutputs(ctx, e.outputAssembler, tCtx, arrayCore.PhaseSuccess, version, pluginState.State)
 
 	case arrayCore.PhaseWriteToDiscoveryThenFail:
-		pluginState.State, err = array.WriteToDiscovery(ctx, tCtx, pluginState.State, arrayCore.PhaseAssembleFinalError, version)
+		// TODO @hamersaw - use externalResource
+		pluginState.State, _, err = array.WriteToDiscovery(ctx, tCtx, pluginState.State, arrayCore.PhaseAssembleFinalError, version)
 
 	case arrayCore.PhaseWriteToDiscovery:
-		pluginState.State, err = array.WriteToDiscovery(ctx, tCtx, pluginState.State, arrayCore.PhaseAssembleFinalOutput, version)
+		// TODO @hamersaw - use externalResource
+		pluginState.State, _, err = array.WriteToDiscovery(ctx, tCtx, pluginState.State, arrayCore.PhaseAssembleFinalOutput, version)
 
 	case arrayCore.PhaseAssembleFinalError:
 		pluginState.State, err = array.AssembleFinalOutputs(ctx, e.errorAssembler, tCtx, arrayCore.PhaseRetryableFailure, version, pluginState.State)

--- a/go/tasks/plugins/array/awsbatch/executor.go
+++ b/go/tasks/plugins/array/awsbatch/executor.go
@@ -71,30 +71,30 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		pluginState.State, err = array.DetermineDiscoverability(ctx, tCtx, pluginConfig.MaxArrayJobSize, pluginState.State)
 
 	case arrayCore.PhasePreLaunch:
-		pluginState, err = EnsureJobDefinition(ctx, tCtx, pluginConfig, e.jobStore.Client, e.jobDefinitionCache, pluginState)
+		pluginState, err = EnsureJobDefinition(ctx, tCtx, pluginConfig, e.jobStore.Client, e.jobDefinitionCache, pluginState, version+1)
 
 	case arrayCore.PhaseWaitingForResources:
 		fallthrough
 
 	case arrayCore.PhaseLaunch:
-		pluginState, err = LaunchSubTasks(ctx, tCtx, e.jobStore, pluginConfig, pluginState, e.metrics)
+		pluginState, err = LaunchSubTasks(ctx, tCtx, e.jobStore, pluginConfig, pluginState, e.metrics, version+1)
 
 	case arrayCore.PhaseCheckingSubTaskExecutions:
 		pluginState, err = CheckSubTasksState(ctx, tCtx, e.jobStore, pluginConfig, pluginState, e.metrics)
 
 	case arrayCore.PhaseAssembleFinalOutput:
-		pluginState.State, err = array.AssembleFinalOutputs(ctx, e.outputAssembler, tCtx, arrayCore.PhaseSuccess, version, pluginState.State)
+		pluginState.State, err = array.AssembleFinalOutputs(ctx, e.outputAssembler, tCtx, arrayCore.PhaseSuccess, version+1, pluginState.State)
 
 	case arrayCore.PhaseWriteToDiscoveryThenFail:
 		// TODO @hamersaw - use externalResource
-		pluginState.State, _, err = array.WriteToDiscovery(ctx, tCtx, pluginState.State, arrayCore.PhaseAssembleFinalError, version)
+		pluginState.State, _, err = array.WriteToDiscovery(ctx, tCtx, pluginState.State, arrayCore.PhaseAssembleFinalError, version+1)
 
 	case arrayCore.PhaseWriteToDiscovery:
 		// TODO @hamersaw - use externalResource
-		pluginState.State, _, err = array.WriteToDiscovery(ctx, tCtx, pluginState.State, arrayCore.PhaseAssembleFinalOutput, version)
+		pluginState.State, _, err = array.WriteToDiscovery(ctx, tCtx, pluginState.State, arrayCore.PhaseAssembleFinalOutput, version+1)
 
 	case arrayCore.PhaseAssembleFinalError:
-		pluginState.State, err = array.AssembleFinalOutputs(ctx, e.errorAssembler, tCtx, arrayCore.PhaseRetryableFailure, version, pluginState.State)
+		pluginState.State, err = array.AssembleFinalOutputs(ctx, e.errorAssembler, tCtx, arrayCore.PhaseRetryableFailure, version+1, pluginState.State)
 	}
 
 	if err != nil {

--- a/go/tasks/plugins/array/awsbatch/job_definition.go
+++ b/go/tasks/plugins/array/awsbatch/job_definition.go
@@ -40,7 +40,7 @@ func containerImageRepository(containerImage string) string {
 }
 
 func EnsureJobDefinition(ctx context.Context, tCtx pluginCore.TaskExecutionContext, cfg *config.Config, client Client,
-	definitionCache definition.Cache, currentState *State) (nextState *State, err error) {
+	definitionCache definition.Cache, currentState *State, terminalVersion uint32) (nextState *State, err error) {
 
 	taskTemplate, err := tCtx.TaskReader().Read(ctx)
 	if err != nil {
@@ -65,7 +65,7 @@ func EnsureJobDefinition(ctx context.Context, tCtx pluginCore.TaskExecutionConte
 			containerImage, role, platformCapabilities, existingArn)
 
 		nextState = currentState.SetJobDefinitionArn(existingArn)
-		nextState.State = nextState.SetPhase(arrayCore.PhaseLaunch, 0).SetReason("AWS job definition already exist.")
+		nextState.State = nextState.SetPhase(arrayCore.PhaseLaunch, terminalVersion).SetReason("AWS job definition already exist.")
 		return nextState, nil
 	}
 
@@ -83,7 +83,7 @@ func EnsureJobDefinition(ctx context.Context, tCtx pluginCore.TaskExecutionConte
 	}
 
 	nextState = currentState.SetJobDefinitionArn(arn)
-	nextState.State = nextState.SetPhase(arrayCore.PhaseLaunch, 0).SetReason("Created AWS job definition")
+	nextState.State = nextState.SetPhase(arrayCore.PhaseLaunch, terminalVersion).SetReason("Created AWS job definition")
 
 	return nextState, nil
 }

--- a/go/tasks/plugins/array/awsbatch/job_definition_test.go
+++ b/go/tasks/plugins/array/awsbatch/job_definition_test.go
@@ -79,7 +79,7 @@ func TestEnsureJobDefinition(t *testing.T) {
 
 		nextState, err := EnsureJobDefinition(ctx, tCtx, cfg, batchClient, dCache, &State{
 			State: &arrayCore.State{},
-		})
+		}, 1)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, nextState)
@@ -95,7 +95,7 @@ func TestEnsureJobDefinition(t *testing.T) {
 
 		nextState, err := EnsureJobDefinition(ctx, tCtx, cfg, batchClient, dCache, &State{
 			State: &arrayCore.State{},
-		})
+		}, 1)
 		assert.NoError(t, err)
 		assert.NotNil(t, nextState)
 		assert.Equal(t, "their-arn", nextState.JobDefinitionArn)
@@ -152,7 +152,7 @@ func TestEnsureJobDefinitionWithSecurityContext(t *testing.T) {
 
 		nextState, err := EnsureJobDefinition(ctx, tCtx, cfg, batchClient, dCache, &State{
 			State: &arrayCore.State{},
-		})
+		}, 1)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, nextState)
@@ -168,7 +168,7 @@ func TestEnsureJobDefinitionWithSecurityContext(t *testing.T) {
 
 		nextState, err := EnsureJobDefinition(ctx, tCtx, cfg, batchClient, dCache, &State{
 			State: &arrayCore.State{},
-		})
+		}, 1)
 		assert.NoError(t, err)
 		assert.NotNil(t, nextState)
 		assert.Equal(t, "their-arn", nextState.JobDefinitionArn)

--- a/go/tasks/plugins/array/awsbatch/job_definition_test.go
+++ b/go/tasks/plugins/array/awsbatch/job_definition_test.go
@@ -79,7 +79,7 @@ func TestEnsureJobDefinition(t *testing.T) {
 
 		nextState, err := EnsureJobDefinition(ctx, tCtx, cfg, batchClient, dCache, &State{
 			State: &arrayCore.State{},
-		}, 1)
+		}, 0)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, nextState)
@@ -95,7 +95,7 @@ func TestEnsureJobDefinition(t *testing.T) {
 
 		nextState, err := EnsureJobDefinition(ctx, tCtx, cfg, batchClient, dCache, &State{
 			State: &arrayCore.State{},
-		}, 1)
+		}, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, nextState)
 		assert.Equal(t, "their-arn", nextState.JobDefinitionArn)
@@ -152,7 +152,7 @@ func TestEnsureJobDefinitionWithSecurityContext(t *testing.T) {
 
 		nextState, err := EnsureJobDefinition(ctx, tCtx, cfg, batchClient, dCache, &State{
 			State: &arrayCore.State{},
-		}, 1)
+		}, 0)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, nextState)
@@ -168,7 +168,7 @@ func TestEnsureJobDefinitionWithSecurityContext(t *testing.T) {
 
 		nextState, err := EnsureJobDefinition(ctx, tCtx, cfg, batchClient, dCache, &State{
 			State: &arrayCore.State{},
-		}, 1)
+		}, 0)
 		assert.NoError(t, err)
 		assert.NotNil(t, nextState)
 		assert.Equal(t, "their-arn", nextState.JobDefinitionArn)

--- a/go/tasks/plugins/array/awsbatch/launcher.go
+++ b/go/tasks/plugins/array/awsbatch/launcher.go
@@ -17,7 +17,7 @@ import (
 )
 
 func LaunchSubTasks(ctx context.Context, tCtx core.TaskExecutionContext, batchClient Client, pluginConfig *config.Config,
-	currentState *State, metrics ExecutorMetrics) (nextState *State, err error) {
+	currentState *State, metrics ExecutorMetrics, terminalVersion uint32) (nextState *State, err error) {
 	size := currentState.GetExecutionArraySize()
 
 	jobDefinition := currentState.GetJobDefinitionArn()
@@ -56,7 +56,7 @@ func LaunchSubTasks(ctx context.Context, tCtx core.TaskExecutionContext, batchCl
 	}
 
 	parentState := currentState.
-		SetPhase(arrayCore.PhaseCheckingSubTaskExecutions, 0).
+		SetPhase(arrayCore.PhaseCheckingSubTaskExecutions, terminalVersion).
 		SetArrayStatus(arraystatus.ArrayStatus{
 			Summary: arraystatus.ArraySummary{
 				core.PhaseQueued: int64(size),

--- a/go/tasks/plugins/array/awsbatch/launcher_test.go
+++ b/go/tasks/plugins/array/awsbatch/launcher_test.go
@@ -134,7 +134,7 @@ func TestLaunchSubTasks(t *testing.T) {
 			JobDefinitionArn: "arn",
 		}
 
-		newState, err := LaunchSubTasks(context.TODO(), tCtx, batchClient, &config.Config{MaxArrayJobSize: 10}, currentState, getAwsBatchExecutorMetrics(promutils.NewTestScope()), 1)
+		newState, err := LaunchSubTasks(context.TODO(), tCtx, batchClient, &config.Config{MaxArrayJobSize: 10}, currentState, getAwsBatchExecutorMetrics(promutils.NewTestScope()), 0)
 		assert.NoError(t, err)
 		assertEqual(t, expectedState, newState)
 	})

--- a/go/tasks/plugins/array/awsbatch/launcher_test.go
+++ b/go/tasks/plugins/array/awsbatch/launcher_test.go
@@ -134,7 +134,7 @@ func TestLaunchSubTasks(t *testing.T) {
 			JobDefinitionArn: "arn",
 		}
 
-		newState, err := LaunchSubTasks(context.TODO(), tCtx, batchClient, &config.Config{MaxArrayJobSize: 10}, currentState, getAwsBatchExecutorMetrics(promutils.NewTestScope()))
+		newState, err := LaunchSubTasks(context.TODO(), tCtx, batchClient, &config.Config{MaxArrayJobSize: 10}, currentState, getAwsBatchExecutorMetrics(promutils.NewTestScope()), 1)
 		assert.NoError(t, err)
 		assertEqual(t, expectedState, newState)
 	})

--- a/go/tasks/plugins/array/awsbatch/monitor.go
+++ b/go/tasks/plugins/array/awsbatch/monitor.go
@@ -167,7 +167,7 @@ func CheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionContext, job
 
 		parentState = parentState.SetPhase(phase, version).SetReason("Task is still running")
 	} else {
-		parentState = parentState.SetPhase(phase, version)
+		parentState = parentState.SetPhase(phase, version+1)
 	}
 
 	p, v := parentState.GetPhase()

--- a/go/tasks/plugins/array/catalog.go
+++ b/go/tasks/plugins/array/catalog.go
@@ -269,7 +269,6 @@ func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state
 	for idx, phaseIdx := range state.ArrayStatus.Detailed.GetItems() {
 		phase := core.Phases[phaseIdx]
 		if !phase.IsSuccess() {
-			// TODO @hamersaw - prove that this is wrong!
 			// tasksToCache is built on the originalArraySize and ArrayStatus.Detailed is the executionArraySize
 			originalIdx := arrayCore.CalculateOriginalIndex(idx, state.GetIndexesToCache())
 			tasksToCache.Clear(uint(originalIdx))

--- a/go/tasks/plugins/array/catalog.go
+++ b/go/tasks/plugins/array/catalog.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"strconv"
 
+	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	idlPlugins "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
 
 	arrayCore "github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core"
@@ -19,8 +20,6 @@ import (
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/ioutils"
-
-	idlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 )
 
 const AwsBatchTaskType = "aws-batch"
@@ -212,19 +211,20 @@ func DetermineDiscoverability(ctx context.Context, tCtx core.TaskExecutionContex
 	return state, nil
 }
 
-func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state *arrayCore.State, phaseOnSuccess arrayCore.Phase, versionOnSuccess uint32) (*arrayCore.State, error) {
+func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state *arrayCore.State, phaseOnSuccess arrayCore.Phase, versionOnSuccess uint32) (*arrayCore.State, []*core.ExternalResource, error) {
+	var externalResources []*core.ExternalResource
 
 	// Check that the taskTemplate is valid
 	taskTemplate, err := tCtx.TaskReader().Read(ctx)
 	if err != nil {
-		return state, err
+		return state, externalResources, err
 	} else if taskTemplate == nil {
-		return state, errors.Errorf(errors.BadTaskSpecification, "Required value not set, taskTemplate is nil")
+		return state, externalResources, errors.Errorf(errors.BadTaskSpecification, "Required value not set, taskTemplate is nil")
 	}
 
 	if tMeta := taskTemplate.Metadata; tMeta == nil || !tMeta.Discoverable {
 		logger.Debugf(ctx, "Task is not marked as discoverable. Moving to [%v] phase.", phaseOnSuccess)
-		return state.SetPhase(phaseOnSuccess, versionOnSuccess).SetReason("Task is not discoverable."), nil
+		return state.SetPhase(phaseOnSuccess, versionOnSuccess).SetReason("Task is not discoverable."), externalResources, nil
 	}
 
 	var inputReaders []io.InputReader
@@ -233,12 +233,12 @@ func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state
 		// input readers
 		inputReaders, err = ConstructRemoteFileInputReaders(ctx, tCtx.DataStore(), tCtx.InputReader().GetInputPrefixPath(), arrayJobSize)
 		if err != nil {
-			return nil, err
+			return nil, externalResources, err
 		}
 	} else {
 		inputs, err := tCtx.InputReader().Get(ctx)
 		if err != nil {
-			return state, errors.Errorf(errors.MetadataAccessFailed, "Could not read inputs and therefore failed to determine array job size")
+			return state, externalResources, errors.Errorf(errors.MetadataAccessFailed, "Could not read inputs and therefore failed to determine array job size")
 		}
 
 		var literalCollection *idlCore.LiteralCollection
@@ -257,18 +257,22 @@ func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state
 	// output reader
 	outputReaders, err := ConstructOutputReaders(ctx, tCtx.DataStore(), tCtx.OutputWriter().GetOutputPrefixPath(), tCtx.OutputWriter().GetRawOutputPrefix(), arrayJobSize)
 	if err != nil {
-		return nil, err
+		return nil, externalResources, err
 	}
 
 	iface := *taskTemplate.Interface
 	iface.Outputs = makeSingularTaskInterface(iface.Outputs)
 
 	// Do not cache failed tasks. Retrieve the final phase from array status and unset the non-successful ones.
+
 	tasksToCache := state.GetIndexesToCache().DeepCopy()
 	for idx, phaseIdx := range state.ArrayStatus.Detailed.GetItems() {
 		phase := core.Phases[phaseIdx]
 		if !phase.IsSuccess() {
-			tasksToCache.Clear(uint(idx))
+			// TODO @hamersaw - prove that this is wrong!
+			// tasksToCache is built on the originalArraySize and ArrayStatus.Detailed is the executionArraySize
+			originalIdx := arrayCore.CalculateOriginalIndex(idx, state.GetIndexesToCache())
+			tasksToCache.Clear(uint(originalIdx))
 		}
 	}
 
@@ -278,24 +282,42 @@ func WriteToDiscovery(ctx context.Context, tCtx core.TaskExecutionContext, state
 		iface, &tasksToCache, inputReaders, outputReaders)
 
 	if err != nil {
-		return nil, err
+		return nil, externalResources, err
 	}
 
 	if len(catalogWriterItems) == 0 {
 		state.SetPhase(phaseOnSuccess, versionOnSuccess).SetReason("No outputs need to be cached.")
-		return state, nil
+		return state, externalResources, nil
 	}
 
 	allWritten, err := WriteToCatalog(ctx, tCtx.TaskRefreshIndicator(), tCtx.Catalog(), catalogWriterItems)
 	if err != nil {
-		return nil, err
+		return nil, externalResources, err
 	}
 
 	if allWritten {
 		state.SetPhase(phaseOnSuccess, versionOnSuccess).SetReason("Finished writing catalog cache.")
+
+		// set CACHE_POPULATED CacheStatus on all cached subtasks
+		externalResources = make([]*core.ExternalResource, 0)
+		for idx, phaseIdx := range state.ArrayStatus.Detailed.GetItems() {
+			originalIdx := arrayCore.CalculateOriginalIndex(idx, state.GetIndexesToCache())
+			if !tasksToCache.IsSet(uint(originalIdx)) {
+				continue
+			}
+
+			externalResources = append(externalResources,
+				&core.ExternalResource{
+					CacheStatus:  idlCore.CatalogCacheStatus_CACHE_POPULATED,
+					Index:        uint32(originalIdx),
+					RetryAttempt: uint32(state.RetryAttempts.GetItem(idx)),
+					Phase:        core.Phases[phaseIdx],
+				},
+			)
+		}
 	}
 
-	return state, nil
+	return state, externalResources, nil
 }
 
 func WriteToCatalog(ctx context.Context, ownerSignal core.SignalAsync, catalogClient catalog.AsyncClient,

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -263,9 +263,8 @@ func SummaryToPhase(ctx context.Context, minSuccesses int64, summary arraystatus
 		return PhaseWriteToDiscoveryThenFail
 	}
 
-	// No chance to reach the required success numbers. If any subtasks are running we let them
-	// complete, so results may be written to cache if enabled, before failing.
-	if totalSuccesses+totalWaitingForResources+totalRetryableFailures < minSuccesses && totalRunning == 0 {
+	// No chance to reach the required success numbers.
+	if totalRunning+totalSuccesses+totalWaitingForResources+totalRetryableFailures < minSuccesses {
 		logger.Infof(ctx, "Array failed early because total failures > minSuccesses[%v]. Snapshot totalRunning[%v] + totalSuccesses[%v] + totalWaitingForResource[%v] + totalRetryableFailures[%v]",
 			minSuccesses, totalRunning, totalSuccesses, totalWaitingForResources, totalRetryableFailures)
 		return PhaseWriteToDiscoveryThenFail

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -209,13 +209,6 @@ func MapArrayStateToPluginPhase(_ context.Context, state *State, logLinks []*idl
 		fallthrough
 
 	case PhaseWriteToDiscovery:
-		// The state version is only incremented in PhaseCheckingSubTaskExecutions when subtask
-		// phases are updated. Therefore by adding the phase to the state version we ensure that
-		// (1) all phase changes will have a new phase version and (2) all subtask phase updates
-		// result in monotonically increasing phase version.
-		//phaseInfo = core.PhaseInfoRunning(version+uint32(p), nowTaskInfo)
-
-		// TODO @hamersaw - get rid of this "+ phase" junk
 		phaseInfo = core.PhaseInfoRunning(version, nowTaskInfo)
 
 	case PhaseSuccess:

--- a/go/tasks/plugins/array/core/state.go
+++ b/go/tasks/plugins/array/core/state.go
@@ -271,7 +271,7 @@ func SummaryToPhase(ctx context.Context, minSuccesses int64, summary arraystatus
 	}
 
 	// No chance to reach the required success numbers. If any subtasks are running we let them
-	// complete, so results may be writen to cache if enabled, before failing.
+	// complete, so results may be written to cache if enabled, before failing.
 	if totalSuccesses+totalWaitingForResources+totalRetryableFailures < minSuccesses && totalRunning == 0 {
 		logger.Infof(ctx, "Array failed early because total failures > minSuccesses[%v]. Snapshot totalRunning[%v] + totalSuccesses[%v] + totalWaitingForResource[%v] + totalRetryableFailures[%v]",
 			minSuccesses, totalRunning, totalSuccesses, totalWaitingForResources, totalRetryableFailures)

--- a/go/tasks/plugins/array/core/state_test.go
+++ b/go/tasks/plugins/array/core/state_test.go
@@ -97,7 +97,7 @@ func TestMapArrayStateToPluginPhase(t *testing.T) {
 		phaseInfo, err := MapArrayStateToPluginPhase(ctx, &s, nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, core.PhaseRunning, phaseInfo.Phase())
-		assert.Equal(t, uint32(12), phaseInfo.Version())
+		assert.Equal(t, uint32(8), phaseInfo.Version())
 	})
 
 	t.Run("write to discovery", func(t *testing.T) {
@@ -116,7 +116,7 @@ func TestMapArrayStateToPluginPhase(t *testing.T) {
 		phaseInfo, err := MapArrayStateToPluginPhase(ctx, &s, nil, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, core.PhaseRunning, phaseInfo.Phase())
-		assert.Equal(t, uint32(14), phaseInfo.Version())
+		assert.Equal(t, uint32(8), phaseInfo.Version())
 	})
 
 	t.Run("success", func(t *testing.T) {
@@ -304,11 +304,11 @@ func TestSummaryToPhase(t *testing.T) {
 			},
 		},
 		{
-			"FailOnToManyPermanentFailures",
+			"FailOnTooManyPermanentFailures",
 			PhaseWriteToDiscoveryThenFail,
 			map[core.Phase]int64{
 				core.PhasePermanentFailure: 1,
-				core.PhaseUndefined:        9,
+				core.PhaseSuccess:          9,
 			},
 		},
 		{

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -88,18 +88,25 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 	case arrayCore.PhaseStart:
 		nextState, err = array.DetermineDiscoverability(ctx, tCtx, pluginConfig.MaxArrayJobSize, pluginState)
 
-	case arrayCore.PhasePreLaunch:
-		nextState = pluginState.SetPhase(arrayCore.PhaseLaunch, core.DefaultPhaseVersion).SetReason("Nothing to do in PreLaunch phase.")
+		nextPhase, _ := nextState.GetPhase()
+		if err == nil && nextPhase != arrayCore.PhaseStart {
+			// TODO @hamersaw
+			// we need to do this here because if cached items are all found we automatically transition to PhaseAssembleFinalOutput
+			// so we need to ensure that we report subtask status' in all cases
 
-		// we wait for PhasePreLaunch to InitializeExternalResources because then the array job
-		// configuration has been validated and all of the metadata necessary to report subtask
-		// status (ie. cache hit / etc) is available.
-		externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, pluginState,
-			func(tCtx core.TaskExecutionContext, childIndex int) string {
-				subTaskExecutionID := NewSubTaskExecutionID(tCtx.TaskExecutionMetadata().GetTaskExecutionID(), childIndex, 0)
-				return subTaskExecutionID.GetGeneratedName()
-			},
-		)
+			// we wait for PhasePreLaunch to InitializeExternalResources because then the array job
+			// configuration has been validated and all of the metadata necessary to report subtask
+			// status (ie. cache hit / etc) is available.
+			externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, nextState,
+				func(tCtx core.TaskExecutionContext, childIndex int) string {
+					subTaskExecutionID := NewSubTaskExecutionID(tCtx.TaskExecutionMetadata().GetTaskExecutionID(), childIndex, 0)
+					return subTaskExecutionID.GetGeneratedName()
+				},
+			)
+		}
+
+	case arrayCore.PhasePreLaunch:
+		nextState = pluginState.SetPhase(arrayCore.PhaseLaunch, version+1).SetReason("Nothing to do in PreLaunch phase.")
 
 	case arrayCore.PhaseWaitingForResources:
 		fallthrough
@@ -108,7 +115,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		// In order to maintain backwards compatibility with the state transitions
 		// in the aws batch plugin. Forward to PhaseCheckingSubTasksExecutions where the launching
 		// is actually occurring.
-		nextState = pluginState.SetPhase(arrayCore.PhaseCheckingSubTaskExecutions, version).SetReason("Nothing to do in Launch phase.")
+		nextState = pluginState.SetPhase(arrayCore.PhaseCheckingSubTaskExecutions, version+1).SetReason("Nothing to do in Launch phase.")
 		err = nil
 
 	case arrayCore.PhaseCheckingSubTaskExecutions:
@@ -116,16 +123,16 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 			tCtx.DataStore(), tCtx.OutputWriter().GetOutputPrefixPath(), tCtx.OutputWriter().GetRawOutputPrefix(), pluginState)
 
 	case arrayCore.PhaseAssembleFinalOutput:
-		nextState, err = array.AssembleFinalOutputs(ctx, e.outputsAssembler, tCtx, arrayCore.PhaseSuccess, version, pluginState)
+		nextState, err = array.AssembleFinalOutputs(ctx, e.outputsAssembler, tCtx, arrayCore.PhaseSuccess, version+1, pluginState)
 
 	case arrayCore.PhaseWriteToDiscoveryThenFail:
-		nextState, err = array.WriteToDiscovery(ctx, tCtx, pluginState, arrayCore.PhaseAssembleFinalError, version)
+		nextState, externalResources, err = array.WriteToDiscovery(ctx, tCtx, pluginState, arrayCore.PhaseAssembleFinalError, version+1)
 
 	case arrayCore.PhaseWriteToDiscovery:
-		nextState, err = array.WriteToDiscovery(ctx, tCtx, pluginState, arrayCore.PhaseAssembleFinalOutput, version)
+		nextState, externalResources, err = array.WriteToDiscovery(ctx, tCtx, pluginState, arrayCore.PhaseAssembleFinalOutput, version+1)
 
 	case arrayCore.PhaseAssembleFinalError:
-		nextState, err = array.AssembleFinalOutputs(ctx, e.errorAssembler, tCtx, arrayCore.PhasePermanentFailure, version, pluginState)
+		nextState, err = array.AssembleFinalOutputs(ctx, e.errorAssembler, tCtx, arrayCore.PhasePermanentFailure, version+1, pluginState)
 
 	default:
 		nextState = pluginState

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -90,12 +90,8 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 
 		nextPhase, _ := nextState.GetPhase()
 		if err == nil && nextPhase != arrayCore.PhaseStart {
-			// TODO @hamersaw
-			// we need to do this here because if cached items are all found we automatically transition to PhaseAssembleFinalOutput
-			// so we need to ensure that we report subtask status' in all cases
-
-			// we wait for PhasePreLaunch to InitializeExternalResources because then the array job
-			// configuration has been validated and all of the metadata necessary to report subtask
+			// we wait to transition out of PhaseStart to InitializeExternalResources because then the array
+			// job configuration has then been validated and all of the metadata necessary to report subtask
 			// status (ie. cache hit / etc) is available.
 			externalResources, err = arrayCore.InitializeExternalResources(ctx, tCtx, nextState,
 				func(tCtx core.TaskExecutionContext, childIndex int) string {

--- a/go/tasks/plugins/array/k8s/management.go
+++ b/go/tasks/plugins/array/k8s/management.go
@@ -320,7 +320,7 @@ func LaunchAndCheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionCon
 
 		newState = newState.SetPhase(phase, version).SetReason("Task is still running")
 	} else {
-		newState = newState.SetPhase(phase, version)
+		newState = newState.SetPhase(phase, version+1)
 	}
 
 	return newState, externalResources, nil


### PR DESCRIPTION
# TL;DR
Cache status of map tasks subtasks is not reported correctly. This PR fixes the issue, where all external resources may be correctly annotated with the correct cache status during execution.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
