### PR TITLE
Additional catalog client functionality for cache eviction

### DIFF
--- a/go/tasks/pluginmachinery/catalog/client.go
+++ b/go/tasks/pluginmachinery/catalog/client.go
@@ -142,11 +142,17 @@ type Client interface {
 	Update(ctx context.Context, key Key, reader io.OutputReader, metadata Metadata) (Status, error)
 	// ReleaseReservation releases an acquired reservation for the given key and owner ID.
 	ReleaseReservation(ctx context.Context, key Key, ownerID string) error
+	// ReleaseReservationByArtifactTag releases an acquired reservation for the given dataset ID, artifact tag and
+	// owner ID.
+	ReleaseReservationByArtifactTag(ctx context.Context, datasetID *datacatalog.DatasetID, artifactTag string, ownerID string) error
 	// Delete removes the artifact associated with the given key and deletes its underlying data from blob storage.
 	Delete(ctx context.Context, key Key) error
 	// DeleteByArtifactTag removes the artifact associated with the given dataset ID and artifact tag and deletes its
 	// underlying data from blob storage.
 	DeleteByArtifactTag(ctx context.Context, datasetID *datacatalog.DatasetID, artifactTag string) error
+	// DeleteByArtifactID removes the artifact associated with the given dataset and artifact ID and deletes its
+	// underlying data from blob storage.
+	DeleteByArtifactID(ctx context.Context, datasetID *datacatalog.DatasetID, artifactID string) error
 }
 
 func IsNotFound(err error) bool {

--- a/go/tasks/pluginmachinery/catalog/mocks/client.go
+++ b/go/tasks/pluginmachinery/catalog/mocks/client.go
@@ -53,6 +53,38 @@ func (_m *Client) Delete(ctx context.Context, key catalog.Key) error {
 	return r0
 }
 
+type Client_DeleteByArtifactID struct {
+	*mock.Call
+}
+
+func (_m Client_DeleteByArtifactID) Return(_a0 error) *Client_DeleteByArtifactID {
+	return &Client_DeleteByArtifactID{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *Client) OnDeleteByArtifactID(ctx context.Context, datasetID *datacatalog.DatasetID, artifactID string) *Client_DeleteByArtifactID {
+	c_call := _m.On("DeleteByArtifactID", ctx, datasetID, artifactID)
+	return &Client_DeleteByArtifactID{Call: c_call}
+}
+
+func (_m *Client) OnDeleteByArtifactIDMatch(matchers ...interface{}) *Client_DeleteByArtifactID {
+	c_call := _m.On("DeleteByArtifactID", matchers...)
+	return &Client_DeleteByArtifactID{Call: c_call}
+}
+
+// DeleteByArtifactID provides a mock function with given fields: ctx, datasetID, artifactID
+func (_m *Client) DeleteByArtifactID(ctx context.Context, datasetID *datacatalog.DatasetID, artifactID string) error {
+	ret := _m.Called(ctx, datasetID, artifactID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *datacatalog.DatasetID, string) error); ok {
+		r0 = rf(ctx, datasetID, artifactID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type Client_DeleteByArtifactTag struct {
 	*mock.Call
 }
@@ -270,6 +302,38 @@ func (_m *Client) ReleaseReservation(ctx context.Context, key catalog.Key, owner
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, catalog.Key, string) error); ok {
 		r0 = rf(ctx, key, ownerID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+type Client_ReleaseReservationByArtifactTag struct {
+	*mock.Call
+}
+
+func (_m Client_ReleaseReservationByArtifactTag) Return(_a0 error) *Client_ReleaseReservationByArtifactTag {
+	return &Client_ReleaseReservationByArtifactTag{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *Client) OnReleaseReservationByArtifactTag(ctx context.Context, datasetID *datacatalog.DatasetID, artifactTag string, ownerID string) *Client_ReleaseReservationByArtifactTag {
+	c_call := _m.On("ReleaseReservationByArtifactTag", ctx, datasetID, artifactTag, ownerID)
+	return &Client_ReleaseReservationByArtifactTag{Call: c_call}
+}
+
+func (_m *Client) OnReleaseReservationByArtifactTagMatch(matchers ...interface{}) *Client_ReleaseReservationByArtifactTag {
+	c_call := _m.On("ReleaseReservationByArtifactTag", matchers...)
+	return &Client_ReleaseReservationByArtifactTag{Call: c_call}
+}
+
+// ReleaseReservationByArtifactTag provides a mock function with given fields: ctx, datasetID, artifactTag, ownerID
+func (_m *Client) ReleaseReservationByArtifactTag(ctx context.Context, datasetID *datacatalog.DatasetID, artifactTag string, ownerID string) error {
+	ret := _m.Called(ctx, datasetID, artifactTag, ownerID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *datacatalog.DatasetID, string, string) error); ok {
+		r0 = rf(ctx, datasetID, artifactTag, ownerID)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
# TL;DR
Added extra methods for accessing and removing artifact data to catalog client.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [X] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
The new `ByArtifactTag` methods were added to allow for easier access to reservations from flyteadmin (which retrieves the artifact tag from its stored metadata without having to access the stored artifact to generate a `catalog.Key`).
Additional functionality for deleting artifacts has been added as well.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/2867

## Follow-up issue
_NA_
