### PR TITLE
PodSpec NodeSelectors overwrite the default k8s plugin settings

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -85,7 +85,7 @@ func UpdatePod(taskExecutionMetadata pluginsCore.TaskExecutionMetadata,
 	if len(podSpec.SchedulerName) == 0 {
 		podSpec.SchedulerName = config.GetK8sPluginConfig().SchedulerName
 	}
-	podSpec.NodeSelector = utils.UnionMaps(podSpec.NodeSelector, config.GetK8sPluginConfig().DefaultNodeSelector)
+	podSpec.NodeSelector = utils.UnionMaps(config.GetK8sPluginConfig().DefaultNodeSelector, podSpec.NodeSelector)
 	if taskExecutionMetadata.IsInterruptible() {
 		podSpec.NodeSelector = utils.UnionMaps(podSpec.NodeSelector, config.GetK8sPluginConfig().InterruptibleNodeSelector)
 	}

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -330,7 +330,7 @@ func toK8sPodInterruptible(t *testing.T) {
 	assert.Len(t, p.Tolerations, 2)
 	assert.Equal(t, "x/flyte", p.Tolerations[1].Key)
 	assert.Equal(t, "interruptible", p.Tolerations[1].Value)
-	assert.Equal(t, 1, len(p.NodeSelector))
+	assert.Equal(t, 2, len(p.NodeSelector))
 	assert.Equal(t, "true", p.NodeSelector["x/interruptible"])
 	assert.EqualValues(
 		t,

--- a/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
+++ b/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
@@ -44,7 +44,7 @@ plugins:
       - FLYTE_AWS_ACCESS_KEY_ID: minio
       - FLYTE_AWS_SECRET_ACCESS_KEY: miniostorage
     default-node-selector:
-      user: 'overwritten value'
+      user: 'default'
     default-pod-security-context:
       runAsUser: 1000
       runAsGroup: 3000

--- a/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
+++ b/go/tasks/pluginmachinery/flytek8s/testdata/config.yaml
@@ -43,6 +43,8 @@ plugins:
       - FLYTE_AWS_ENDPOINT: "http://minio.flyte:9000"
       - FLYTE_AWS_ACCESS_KEY_ID: minio
       - FLYTE_AWS_SECRET_ACCESS_KEY: miniostorage
+    default-node-selector:
+      user: 'overwritten value'
     default-pod-security-context:
       runAsUser: 1000
       runAsGroup: 3000

--- a/go/tasks/plugins/array/k8s/subtask.go
+++ b/go/tasks/plugins/array/k8s/subtask.go
@@ -62,7 +62,7 @@ func addMetadata(stCtx SubTaskExecutionContext, cfg *Config, k8sPluginCfg *confi
 
 	pod.SetNamespace(namespace)
 	pod.SetAnnotations(utils.UnionMaps(k8sPluginCfg.DefaultAnnotations, pod.GetAnnotations(), utils.CopyMap(taskExecutionMetadata.GetAnnotations())))
-	pod.SetLabels(utils.UnionMaps(pod.GetLabels(), utils.CopyMap(taskExecutionMetadata.GetLabels()), k8sPluginCfg.DefaultLabels))
+	pod.SetLabels(utils.UnionMaps(k8sPluginCfg.DefaultLabels, pod.GetLabels(), utils.CopyMap(taskExecutionMetadata.GetLabels())))
 	pod.SetName(taskExecutionMetadata.GetTaskExecutionID().GetGeneratedName())
 
 	if !cfg.RemoteClusterConfig.Enabled {


### PR DESCRIPTION
# TL;DR
Currently the `NodeSelectors` on `PodTasks` do not overwrite the k8s plugin default node selectors, rather it is the opposite. This means that if the same `NodeSelector` exists in both locations the k8s plugin is preferred. This PR changes the preference so that `NodeSelectors` on the `PodTask` overwrite those specified as defaults in the k8s plugin configuration.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
