### PR TITLE
Add env FLYTE_FAIL_ON_ERROR to aws batch job

### DIFF
--- a/go/tasks/plugins/array/awsbatch/monitor.go
+++ b/go/tasks/plugins/array/awsbatch/monitor.go
@@ -145,14 +145,6 @@ func CheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionContext, job
 	// Based on the summary produced above, deduce the overall phase of the task.
 	phase := arrayCore.SummaryToPhase(ctx, currentState.GetOriginalMinSuccesses()-currentState.GetOriginalArraySize()+int64(currentState.GetExecutionArraySize()), newArrayStatus.Summary)
 
-	if job.Status.Phase.IsSuccess() && phase == arrayCore.PhaseCheckingSubTaskExecutions {
-		// In some cases, batch job succeed, but all subtasks failed.
-		// The reason for this is that Flytekit catches the exception and writes error.pb to the bucket.
-		// Flyte gets status of the subtask from error.pb in the bucket,
-		// while AWS batch gets it from the return code of subtask.
-		phase = arrayCore.PhasePermanentFailure
-	}
-
 	if phase != arrayCore.PhaseCheckingSubTaskExecutions {
 		metrics.SubTasksSucceeded.Add(ctx, float64(newArrayStatus.Summary[core.PhaseSuccess]))
 		totalFailed := newArrayStatus.Summary[core.PhasePermanentFailure] + newArrayStatus.Summary[core.PhaseRetryableFailure]

--- a/go/tasks/plugins/array/awsbatch/monitor.go
+++ b/go/tasks/plugins/array/awsbatch/monitor.go
@@ -145,6 +145,14 @@ func CheckSubTasksState(ctx context.Context, tCtx core.TaskExecutionContext, job
 	// Based on the summary produced above, deduce the overall phase of the task.
 	phase := arrayCore.SummaryToPhase(ctx, currentState.GetOriginalMinSuccesses()-currentState.GetOriginalArraySize()+int64(currentState.GetExecutionArraySize()), newArrayStatus.Summary)
 
+	if job.Status.Phase.IsSuccess() && phase == arrayCore.PhaseCheckingSubTaskExecutions {
+		// In some cases, batch job succeed, but all subtasks failed.
+		// The reason for this is that Flytekit catches the exception and writes error.pb to the bucket.
+		// Flyte gets status of the subtask from error.pb in the bucket,
+		// while AWS batch gets it from the return code of subtask.
+		phase = arrayCore.PhasePermanentFailure
+	}
+
 	if phase != arrayCore.PhaseCheckingSubTaskExecutions {
 		metrics.SubTasksSucceeded.Add(ctx, float64(newArrayStatus.Summary[core.PhaseSuccess]))
 		totalFailed := newArrayStatus.Summary[core.PhasePermanentFailure] + newArrayStatus.Summary[core.PhaseRetryableFailure]

--- a/go/tasks/plugins/array/awsbatch/transformer.go
+++ b/go/tasks/plugins/array/awsbatch/transformer.go
@@ -118,7 +118,7 @@ func UpdateBatchInputForArray(_ context.Context, batchInput *batch.SubmitJobInpu
 		envVars = append(envVars, &batch.KeyValuePair{Name: refStr(ArrayJobIndex), Value: refStr("FAKE_JOB_ARRAY_INDEX")},
 			&batch.KeyValuePair{Name: refStr("FAKE_JOB_ARRAY_INDEX"), Value: refStr("0")})
 	}
-
+	envVars = append(envVars, &batch.KeyValuePair{Name: refStr("FLYTE_FAIL_ON_ERROR"), Value: refStr("True")})
 	batchInput.ArrayProperties = arrayProps
 	batchInput.ContainerOverrides.Environment = envVars
 

--- a/go/tasks/plugins/array/awsbatch/transformer.go
+++ b/go/tasks/plugins/array/awsbatch/transformer.go
@@ -25,6 +25,7 @@ import (
 const (
 	ArrayJobIndex       = "BATCH_JOB_ARRAY_INDEX_VAR_NAME"
 	arrayJobIDFormatter = "%v:%v"
+	failOnError         = "FLYTE_FAIL_ON_ERROR"
 )
 
 const assignResources = true
@@ -118,7 +119,7 @@ func UpdateBatchInputForArray(_ context.Context, batchInput *batch.SubmitJobInpu
 		envVars = append(envVars, &batch.KeyValuePair{Name: refStr(ArrayJobIndex), Value: refStr("FAKE_JOB_ARRAY_INDEX")},
 			&batch.KeyValuePair{Name: refStr("FAKE_JOB_ARRAY_INDEX"), Value: refStr("0")})
 	}
-	envVars = append(envVars, &batch.KeyValuePair{Name: refStr("FLYTE_FAIL_ON_ERROR"), Value: refStr("True")})
+	envVars = append(envVars, &batch.KeyValuePair{Name: refStr(failOnError), Value: refStr("True")})
 	batchInput.ArrayProperties = arrayProps
 	batchInput.ContainerOverrides.Environment = envVars
 

--- a/go/tasks/plugins/array/awsbatch/transformer.go
+++ b/go/tasks/plugins/array/awsbatch/transformer.go
@@ -119,7 +119,6 @@ func UpdateBatchInputForArray(_ context.Context, batchInput *batch.SubmitJobInpu
 		envVars = append(envVars, &batch.KeyValuePair{Name: refStr(ArrayJobIndex), Value: refStr("FAKE_JOB_ARRAY_INDEX")},
 			&batch.KeyValuePair{Name: refStr("FAKE_JOB_ARRAY_INDEX"), Value: refStr("0")})
 	}
-	envVars = append(envVars, &batch.KeyValuePair{Name: refStr(failOnError), Value: refStr("True")})
 	batchInput.ArrayProperties = arrayProps
 	batchInput.ContainerOverrides.Environment = envVars
 
@@ -145,7 +144,7 @@ func getEnvVarsForTask(ctx context.Context, execID pluginCore.TaskExecutionID, c
 			Value: val,
 		})
 	}
-
+	finalEnvVars = append(finalEnvVars, v1.EnvVar{Name: failOnError, Value: "true"})
 	return finalEnvVars
 }
 

--- a/go/tasks/plugins/array/awsbatch/transformer.go
+++ b/go/tasks/plugins/array/awsbatch/transformer.go
@@ -136,7 +136,7 @@ func getEnvVarsForTask(ctx context.Context, execID pluginCore.TaskExecutionID, c
 	for key, value := range defaultEnvVars {
 		m[key] = value
 	}
-
+	m[failOnError] = "true"
 	finalEnvVars := make([]v1.EnvVar, 0, len(m))
 	for key, val := range m {
 		finalEnvVars = append(finalEnvVars, v1.EnvVar{
@@ -144,7 +144,6 @@ func getEnvVarsForTask(ctx context.Context, execID pluginCore.TaskExecutionID, c
 			Value: val,
 		})
 	}
-	finalEnvVars = append(finalEnvVars, v1.EnvVar{Name: failOnError, Value: "true"})
 	return finalEnvVars
 }
 

--- a/go/tasks/plugins/array/awsbatch/transformer_test.go
+++ b/go/tasks/plugins/array/awsbatch/transformer_test.go
@@ -131,6 +131,7 @@ func TestArrayJobToBatchInput(t *testing.T) {
 			Command: []*string{ref("cmd"), ref("/inputs/prefix")},
 			Environment: []*batch.KeyValuePair{
 				{Name: refStr("BATCH_JOB_ARRAY_INDEX_VAR_NAME"), Value: refStr("AWS_BATCH_JOB_ARRAY_INDEX")},
+				{Name: ref(failOnError), Value: refStr("True")},
 			},
 			Memory: refInt(1074),
 			Vcpus:  refInt(1),

--- a/go/tasks/plugins/array/awsbatch/transformer_test.go
+++ b/go/tasks/plugins/array/awsbatch/transformer_test.go
@@ -238,5 +238,9 @@ func Test_getEnvVarsForTask(t *testing.T) {
 			Name:  "MyKey",
 			Value: "MyVal",
 		},
+		{
+			Name:  "FLYTE_FAIL_ON_ERROR",
+			Value: "true",
+		},
 	}, envVars)
 }

--- a/go/tasks/plugins/array/awsbatch/transformer_test.go
+++ b/go/tasks/plugins/array/awsbatch/transformer_test.go
@@ -130,8 +130,8 @@ func TestArrayJobToBatchInput(t *testing.T) {
 		ContainerOverrides: &batch.ContainerOverrides{
 			Command: []*string{ref("cmd"), ref("/inputs/prefix")},
 			Environment: []*batch.KeyValuePair{
+				{Name: ref(failOnError), Value: refStr("true")},
 				{Name: refStr("BATCH_JOB_ARRAY_INDEX_VAR_NAME"), Value: refStr("AWS_BATCH_JOB_ARRAY_INDEX")},
-				{Name: ref(failOnError), Value: refStr("True")},
 			},
 			Memory: refInt(1074),
 			Vcpus:  refInt(1),


### PR DESCRIPTION
Signed-off-by: Kevin Su <pingsutw@apache.org>

# TL;DR
Add env FLYTE_FAIL_ON_ERROR to aws batch job, so the flytekit will return error code once the job fail.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
<img width="1705" alt="image" src="https://user-images.githubusercontent.com/37936015/210976757-aa31507f-86e6-4474-8e66-2dcf7281f208.png">

## Tracking Issue
https://flyte-org.slack.com/archives/C01P3B761A6/p1664972219043289

## Follow-up issue
_NA_