### PR TITLE
Discard fields when replica number equals zero to avoid api client error

### DIFF
--- a/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
+++ b/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
@@ -2,26 +2,27 @@ package pytorch
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/common"
-
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
+
 	flyteerr "github.com/flyteorg/flyteplugins/go/tasks/errors"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery"
-	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-
 	pluginsCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/k8s"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
+	"github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/common"
 
 	commonOp "github.com/kubeflow/common/pkg/apis/common/v1"
 	kubeflowv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
+
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type pytorchOperatorResourceHandler struct {
@@ -82,6 +83,9 @@ func (pytorchOperatorResourceHandler) BuildResource(ctx context.Context, taskCtx
 	}
 
 	workers := pytorchTaskExtraArgs.GetWorkers()
+	if workers == 0 {
+		return nil, fmt.Errorf("number of worker should be more then 0")
+	}
 
 	jobSpec := kubeflowv1.PyTorchJobSpec{
 		PyTorchReplicaSpecs: map[commonOp.ReplicaType]*commonOp.ReplicaSpec{

--- a/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
+++ b/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
@@ -2,26 +2,27 @@ package tensorflow
 
 import (
 	"context"
+	"fmt"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/common"
-
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/plugins"
+
 	flyteerr "github.com/flyteorg/flyteplugins/go/tasks/errors"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery"
-	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/kubernetes/scheme"
-
 	pluginsCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/k8s"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils"
+	"github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/common"
 
 	commonOp "github.com/kubeflow/common/pkg/apis/common/v1"
 	kubeflowv1 "github.com/kubeflow/training-operator/pkg/apis/kubeflow.org/v1"
+
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type tensorflowOperatorResourceHandler struct {
@@ -85,24 +86,32 @@ func (tensorflowOperatorResourceHandler) BuildResource(ctx context.Context, task
 	psReplicas := tensorflowTaskExtraArgs.GetPsReplicas()
 	chiefReplicas := tensorflowTaskExtraArgs.GetChiefReplicas()
 
+	if workers == 0 {
+		return nil, fmt.Errorf("number of worker should be more then 0")
+	}
+	if psReplicas == 0 && chiefReplicas == 0 {
+		return nil, fmt.Errorf("either number of chief or parameter servers needs to be be more then 0")
+	}
+
 	jobSpec := kubeflowv1.TFJobSpec{
 		TFReplicaSpecs: map[commonOp.ReplicaType]*commonOp.ReplicaSpec{},
 	}
 
 	for _, t := range []struct {
+		podSpec     v1.PodSpec
 		replicaNum  *int32
 		replicaType commonOp.ReplicaType
 	}{
-		{&workers, kubeflowv1.TFJobReplicaTypeWorker},
-		{&psReplicas, kubeflowv1.TFJobReplicaTypePS},
-		{&chiefReplicas, kubeflowv1.TFJobReplicaTypeChief},
+		{*podSpec, &workers, kubeflowv1.TFJobReplicaTypeWorker},
+		{*podSpec, &psReplicas, kubeflowv1.TFJobReplicaTypePS},
+		{*podSpec, &chiefReplicas, kubeflowv1.TFJobReplicaTypeChief},
 	} {
 		if *t.replicaNum > 0 {
 			jobSpec.TFReplicaSpecs[t.replicaType] = &commonOp.ReplicaSpec{
 				Replicas: t.replicaNum,
 				Template: v1.PodTemplateSpec{
 					ObjectMeta: objectMeta,
-					Spec:       *podSpec,
+					Spec:       t.podSpec,
 				},
 				RestartPolicy: commonOp.RestartPolicyNever,
 			}

--- a/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow_test.go
+++ b/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow_test.go
@@ -373,7 +373,7 @@ func TestGetProperties(t *testing.T) {
 }
 
 func TestZeroReplicas(t *testing.T) {
-	// if the number of replicas is zero, the field should not be created or the client might complain.
+	// if the number of replicas is zero, the field should not be created because the api client might complain.
 
 	tensorflowResourceHandler := tensorflowOperatorResourceHandler{}
 


### PR DESCRIPTION
# TL;DR

In some versions of tensorflow CRD, there is an enforcement to restrict the minimum number of replica. If users pass in 0 as the number of replicas, the k8s client will **throw an error** at runtime. The field should be discarded if the number of replicas is zero.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

### Bug
In [the order version of tfjob CRD](https://gist.github.com/ByronHsu/2b484d53bcb4a361bf9af9fb303c8896), it will validate the minimum number of replicas. If the replica == 0 but the field exists, the kubeflow client will fail.

## Test

```
byhsu@byhsu-ld1 ~/local-repo/flyte/flyteplugins gh-tf-replica-bug* ❯ go test github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow    0.072s
```

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue
