### PR TITLE
Only create copilot sidecars if interface requires

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -175,7 +175,7 @@ func AddCoPilotToContainer(ctx context.Context, cfg config.FlyteCoPilotConfig, c
 	c.SecurityContext.Capabilities.Add = append(c.SecurityContext.Capabilities.Add, pTraceCapability)
 
 	if iFace != nil {
-		if iFace.Inputs != nil && iFace.Inputs.Variables != nil && len(iFace.Inputs.Variables) > 0 {
+		if iFace.Inputs != nil && len(iFace.Inputs.Variables) > 0 {
 			inPath := cfg.DefaultInputDataPath
 			if pilot.GetInputPath() != "" {
 				inPath = pilot.GetInputPath()
@@ -187,7 +187,7 @@ func AddCoPilotToContainer(ctx context.Context, cfg config.FlyteCoPilotConfig, c
 			})
 		}
 
-		if iFace.Outputs != nil && iFace.Outputs.Variables != nil && len(iFace.Outputs.Variables) > 0 {
+		if iFace.Outputs != nil && len(iFace.Outputs.Variables) > 0 {
 			outPath := cfg.DefaultOutputPath
 			if pilot.GetOutputPath() != "" {
 				outPath = pilot.GetOutputPath()
@@ -210,7 +210,7 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 	shareProcessNamespaceEnabled := true
 	coPilotPod.ShareProcessNamespace = &shareProcessNamespaceEnabled
 	if iFace != nil {
-		if iFace.Inputs != nil && iFace.Inputs.Variables != nil && len(iFace.Inputs.Variables) > 0 {
+		if iFace.Inputs != nil && len(iFace.Inputs.Variables) > 0 {
 			inPath := cfg.DefaultInputDataPath
 			if pilot.GetInputPath() != "" {
 				inPath = pilot.GetInputPath()
@@ -240,7 +240,7 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 			coPilotPod.InitContainers = append(coPilotPod.InitContainers, downloader)
 		}
 
-		if iFace.Outputs != nil && iFace.Outputs.Variables != nil && len(iFace.Outputs.Variables) > 0 {
+		if iFace.Outputs != nil && len(iFace.Outputs.Variables) > 0 {
 			outPath := cfg.DefaultOutputPath
 			if pilot.GetOutputPath() != "" {
 				outPath = pilot.GetOutputPath()

--- a/go/tasks/pluginmachinery/flytek8s/copilot.go
+++ b/go/tasks/pluginmachinery/flytek8s/copilot.go
@@ -175,7 +175,7 @@ func AddCoPilotToContainer(ctx context.Context, cfg config.FlyteCoPilotConfig, c
 	c.SecurityContext.Capabilities.Add = append(c.SecurityContext.Capabilities.Add, pTraceCapability)
 
 	if iFace != nil {
-		if iFace.Inputs != nil {
+		if iFace.Inputs != nil && iFace.Inputs.Variables != nil && len(iFace.Inputs.Variables) > 0 {
 			inPath := cfg.DefaultInputDataPath
 			if pilot.GetInputPath() != "" {
 				inPath = pilot.GetInputPath()
@@ -187,7 +187,7 @@ func AddCoPilotToContainer(ctx context.Context, cfg config.FlyteCoPilotConfig, c
 			})
 		}
 
-		if iFace.Outputs != nil {
+		if iFace.Outputs != nil && iFace.Outputs.Variables != nil && len(iFace.Outputs.Variables) > 0 {
 			outPath := cfg.DefaultOutputPath
 			if pilot.GetOutputPath() != "" {
 				outPath = pilot.GetOutputPath()
@@ -210,7 +210,7 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 	shareProcessNamespaceEnabled := true
 	coPilotPod.ShareProcessNamespace = &shareProcessNamespaceEnabled
 	if iFace != nil {
-		if iFace.Inputs != nil {
+		if iFace.Inputs != nil && iFace.Inputs.Variables != nil && len(iFace.Inputs.Variables) > 0 {
 			inPath := cfg.DefaultInputDataPath
 			if pilot.GetInputPath() != "" {
 				inPath = pilot.GetInputPath()
@@ -240,7 +240,7 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 			coPilotPod.InitContainers = append(coPilotPod.InitContainers, downloader)
 		}
 
-		if iFace.Outputs != nil {
+		if iFace.Outputs != nil && iFace.Outputs.Variables != nil && len(iFace.Outputs.Variables) > 0 {
 			outPath := cfg.DefaultOutputPath
 			if pilot.GetOutputPath() != "" {
 				outPath = pilot.GetOutputPath()
@@ -268,7 +268,6 @@ func AddCoPilotToPod(ctx context.Context, cfg config.FlyteCoPilotConfig, coPilot
 			}
 			coPilotPod.Containers = append(coPilotPod.Containers, sidecar)
 		}
-
 	}
 
 	return nil


### PR DESCRIPTION
# TL;DR
Currently, Flyte injects a copilot init container to download inputs and a sidecar container to upload outputs of a task. This process only checks if the interface has inputs / outputs defined as `nil`, rather then checking if the variable list exists and is empty as well. This means, depending on the definition, Flyte may inject a container to, for example, upload the outputs of a task when that task does not have any outputs. This PR validates variable existence to ensure copilot sidcars are not unnecessarily created.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3254

## Follow-up issue
_NA_
