### PR TITLE
If primaryContainerName=="primary", container content will be duplicated

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -327,7 +327,6 @@ func mergePodSpecs(basePodSpec *v1.PodSpec, podSpec *v1.PodSpec, primaryContaine
 	}
 
 	// extract defaultContainerTemplate and primaryContainerTemplate
-	var mergedContainers []v1.Container
 	var defaultContainerTemplate, primaryContainerTemplate *v1.Container
 	for i := 0; i < len(basePodSpec.Containers); i++ {
 		if basePodSpec.Containers[i].Name == defaultContainerTemplateName {
@@ -343,6 +342,8 @@ func mergePodSpecs(basePodSpec *v1.PodSpec, podSpec *v1.PodSpec, primaryContaine
 		return nil, err
 	}
 
+	// merge PodTemplate containers
+	var mergedContainers []v1.Container
 	for _, container := range podSpec.Containers {
 		// if applicable start with defaultContainerTemplate
 		var mergedContainer *v1.Container

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -326,21 +326,21 @@ func mergePodSpecs(basePodSpec *v1.PodSpec, podSpec *v1.PodSpec, primaryContaine
 		return nil, errors.New("neither the basePodSpec or the podSpec can be nil")
 	}
 
+	// extract defaultContainerTemplate and primaryContainerTemplate
+	var mergedContainers []v1.Container
+	var defaultContainerTemplate, primaryContainerTemplate *v1.Container
+	for i := 0; i < len(basePodSpec.Containers); i++ {
+		if basePodSpec.Containers[i].Name == defaultContainerTemplateName {
+			defaultContainerTemplate = &basePodSpec.Containers[i]
+		} else if basePodSpec.Containers[i].Name == primaryContainerTemplateName {
+			primaryContainerTemplate = &basePodSpec.Containers[i]
+		}
+	}
+
 	// merge PodTemplate PodSpec with podSpec
 	var mergedPodSpec *v1.PodSpec = basePodSpec.DeepCopy()
 	if err := mergo.Merge(mergedPodSpec, podSpec, mergo.WithOverride, mergo.WithAppendSlice); err != nil {
 		return nil, err
-	}
-
-	// merge template Containers
-	var mergedContainers []v1.Container
-	var defaultContainerTemplate, primaryContainerTemplate *v1.Container
-	for i := 0; i < len(mergedPodSpec.Containers); i++ {
-		if mergedPodSpec.Containers[i].Name == defaultContainerTemplateName {
-			defaultContainerTemplate = &mergedPodSpec.Containers[i]
-		} else if mergedPodSpec.Containers[i].Name == primaryContainerTemplateName {
-			primaryContainerTemplate = &mergedPodSpec.Containers[i]
-		}
 	}
 
 	for _, container := range podSpec.Containers {

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -1315,4 +1315,22 @@ func TestMergePodSpecs(t *testing.T) {
 	defaultContainer := mergedPodSpec.Containers[1]
 	assert.Equal(t, podSpec.Containers[1].Name, defaultContainer.Name)
 	assert.Equal(t, defaultContainerTemplate.TerminationMessagePath, defaultContainer.TerminationMessagePath)
+
+	// validate container content is not duplicated
+	podSpec = v1.PodSpec{
+		Containers: []v1.Container{
+			v1.Container{
+				Name: "primary",
+				VolumeMounts: []v1.VolumeMount{
+					{
+						Name:      "nccl",
+						MountPath: "abc",
+					},
+				},
+			},
+		},
+	}
+	mergedPodSpec, err = mergePodSpecs(&podTemplateSpec, &podSpec, "primary")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(mergedPodSpec.Containers[0].VolumeMounts))
 }


### PR DESCRIPTION
# TL;DR
If primaryContainerName=="primary", container content will be duplicated

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Test

```
byhsu@byhsu-ld1 ~/local-repo/flyte/flyteplugins byronhsu/podmerge ❯ make test_unit                     
Makefile:11: warning: overriding recipe for target `generate'
boilerplate/flyte/golang_test_targets/Makefile:13: warning: ignoring old recipe for target `generate'
go test -cover ./... -race
ok      github.com/flyteorg/flyteplugins/go/tasks       0.361s  coverage: [no statements]
ok      github.com/flyteorg/flyteplugins/go/tasks/aws   0.070s  coverage: 36.5% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/config        [no test files]
?       github.com/flyteorg/flyteplugins/go/tasks/errors        [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/logs  0.156s  coverage: 71.2% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery       [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/bundle        0.314s  coverage: 83.3% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/catalog       0.115s  coverage: 39.0% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/catalog/mocks [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core  0.243s  coverage: 28.0% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks    [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/template 0.311s  coverage: 81.9% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/encoding      0.086s  coverage: 100.0% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s      0.821s  coverage: 86.6% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s/config       0.097s  coverage: 54.3% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/google        [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/internal/webapi       2.286s  coverage: 55.5% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/internal/webapi/mocks [no test files]
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io    [no test files]
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io/mocks      [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/ioutils       0.338s  coverage: 49.7% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/k8s   [no test files]
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/k8s/mocks     [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/tasklog       0.085s  coverage: 94.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils 0.082s  coverage: 62.3% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils/secrets 0.081s  coverage: 83.3% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi        0.261s  coverage: 40.0% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi/example        0.282s  coverage: 33.3% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi/mocks  [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/workqueue     0.199s  coverage: 80.6% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/workqueue/mocks       [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array 0.505s  coverage: 58.7% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/arraystatus     0.208s  coverage: 93.9% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/awsbatch        0.470s  coverage: 71.3% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/awsbatch/config 0.091s  coverage: 59.0% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/awsbatch/definition     0.047s  coverage: 53.3% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/plugins/array/awsbatch/mocks  [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core    0.298s  coverage: 68.1% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/errorcollector  0.089s  coverage: 96.2% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/k8s     1.460s  coverage: 52.8% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/plugins/awsutils      [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/hive  0.406s  coverage: 65.7% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/hive/client   0.059s  coverage: 80.0% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/plugins/hive/client/mocks     [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/hive/config   0.053s  coverage: 39.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/dask      0.340s  coverage: 85.2% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/common        0.259s  coverage: 79.7% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/mpi   0.585s  coverage: 82.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch       0.684s  coverage: 77.8% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow    0.710s  coverage: 82.2% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/pod       0.607s  coverage: 85.5% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/ray       0.356s  coverage: 63.6% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/sagemaker 0.593s  coverage: 74.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/sagemaker/config  0.039s  coverage: 21.7% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/spark     0.428s  coverage: 81.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/presto        0.348s  coverage: 48.8% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/plugins/presto/client [no test files]
?       github.com/flyteorg/flyteplugins/go/tasks/plugins/presto/client/mocks   [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/presto/config 0.038s  coverage: 47.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/webapi/athena 0.233s  coverage: 36.6% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/webapi/bigquery       10.210s coverage: 68.6% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/webapi/databricks     5.180s  coverage: 72.7% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/webapi/snowflake      5.204s  coverage: 71.4% of statements
?       github.com/flyteorg/flyteplugins/tests  [no test files]
```

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

```
	podSpec = v1.PodSpec{
		Containers: []v1.Container{
			v1.Container{
				Name: "primary",
				VolumeMounts: []v1.VolumeMount{
					{
						Name:      "nccl",
						MountPath: "abc",
					},
				},
			},
		},
	}
```

If primaryContainerName=="primary", after merging, volumes will be duplicated.

```
				VolumeMounts: []v1.VolumeMount{
					{
						Name:      "nccl",
						MountPath: "abc",
					},
					{
						Name:      "nccl",
						MountPath: "abc",
					},
				},
```

`mergePodSpecs` logic is wrong. `defaultContainerTemplate, primaryContainerTemplate` should be extracted before merging happens.
