### PR TITLE
Remove chief!=0 or ps!=0 assertion in tensorflow

### DIFF
--- a/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
+++ b/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
@@ -75,9 +75,6 @@ func (tensorflowOperatorResourceHandler) BuildResource(ctx context.Context, task
 	if workers == 0 {
 		return nil, fmt.Errorf("number of worker should be more then 0")
 	}
-	if psReplicas == 0 && chiefReplicas == 0 {
-		return nil, fmt.Errorf("either number of chief or parameter servers needs to be be more then 0")
-	}
 
 	jobSpec := kubeflowv1.TFJobSpec{
 		TFReplicaSpecs: map[commonOp.ReplicaType]*commonOp.ReplicaSpec{},

--- a/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow_test.go
+++ b/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow_test.go
@@ -383,7 +383,6 @@ func TestReplicaCounts(t *testing.T) {
 		notContains        []commonOp.ReplicaType
 	}{
 		{"NoWorkers", 1, 1, 0, true, nil, nil},
-		{"NoChiefOrPS", 0, 0, 1, true, nil, nil},
 		{"SingleChief", 1, 0, 1, false,
 			[]commonOp.ReplicaType{kubeflowv1.TFJobReplicaTypeChief, kubeflowv1.TFJobReplicaTypeWorker},
 			[]commonOp.ReplicaType{kubeflowv1.TFJobReplicaTypePS}},


### PR DESCRIPTION
# TL;DR

Remove chief!=0 or ps!=0 assertion in tensorflow

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Test

```
byhsu@byhsu-ld1 ~/local-repo/flyte/flyteplugins gh-master* 14s ❯ make test_unit
Makefile:11: warning: overriding recipe for target `generate'
boilerplate/flyte/golang_test_targets/Makefile:13: warning: ignoring old recipe for target `generate'
go test -cover ./... -race
ok      github.com/flyteorg/flyteplugins/go/tasks       (cached)        coverage: [no statements]
ok      github.com/flyteorg/flyteplugins/go/tasks/aws   (cached)        coverage: 36.5% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/config        [no test files]
?       github.com/flyteorg/flyteplugins/go/tasks/errors        [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/logs  (cached)        coverage: 71.2% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery       [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/bundle        (cached)        coverage: 83.3% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/catalog       (cached)        coverage: 39.0% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/catalog/mocks [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core  (cached)        coverage: 28.0% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks    [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/template (cached)        coverage: 81.9% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/encoding      (cached)        coverage: 100.0% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s      (cached)        coverage: 86.6% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/flytek8s/config       (cached)        coverage: 54.3% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/google        [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/internal/webapi       (cached)        coverage: 55.5% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/internal/webapi/mocks [no test files]
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io    [no test files]
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io/mocks      [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/ioutils       (cached)        coverage: 49.7% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/k8s   [no test files]
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/k8s/mocks     [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/tasklog       (cached)        coverage: 94.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils (cached)        coverage: 62.3% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/utils/secrets (cached)        coverage: 83.3% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi        (cached)        coverage: 40.0% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi/example        (cached)        coverage: 33.3% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi/mocks  [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/workqueue     (cached)        coverage: 80.6% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/workqueue/mocks       [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array (cached)        coverage: 58.7% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/arraystatus     (cached)        coverage: 93.9% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/awsbatch        (cached)        coverage: 71.3% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/awsbatch/config (cached)        coverage: 59.0% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/awsbatch/definition     (cached)        coverage: 53.3% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/plugins/array/awsbatch/mocks  [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/core    (cached)        coverage: 68.1% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/errorcollector  (cached)        coverage: 96.2% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/array/k8s     (cached)        coverage: 52.8% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/plugins/awsutils      [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/hive  (cached)        coverage: 65.7% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/hive/client   (cached)        coverage: 80.0% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/plugins/hive/client/mocks     [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/hive/config   (cached)        coverage: 39.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/dask      (cached)        coverage: 85.2% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/common        (cached)        coverage: 79.7% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/mpi   (cached)        coverage: 82.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/pytorch       (cached)        coverage: 77.8% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/kfoperators/tensorflow    0.358s  coverage: 81.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/pod       (cached)        coverage: 85.5% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/ray       (cached)        coverage: 63.6% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/sagemaker (cached)        coverage: 74.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/sagemaker/config  (cached)        coverage: 21.7% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/k8s/spark     (cached)        coverage: 81.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/presto        (cached)        coverage: 48.8% of statements
?       github.com/flyteorg/flyteplugins/go/tasks/plugins/presto/client [no test files]
?       github.com/flyteorg/flyteplugins/go/tasks/plugins/presto/client/mocks   [no test files]
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/presto/config (cached)        coverage: 47.4% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/webapi/athena (cached)        coverage: 36.6% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/webapi/bigquery       (cached)        coverage: 68.6% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/webapi/databricks     (cached)        coverage: 72.7% of statements
ok      github.com/flyteorg/flyteplugins/go/tasks/plugins/webapi/snowflake      (cached)        coverage: 71.4% of statements
?       github.com/flyteorg/flyteplugins/tests  [no test files]
```

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

In [tf.distribute.MultiWorkerMirroredStrategy](https://www.tensorflow.org/api_docs/python/tf/distribute/MultiWorkerMirroredStrategy), there can only be workers, without chief and ps.
