### PR TITLE
persisting k8s plugin phase, version, and reason

### DIFF
--- a/go/tasks/pluginmachinery/core/phase.go
+++ b/go/tasks/pluginmachinery/core/phase.go
@@ -136,6 +136,16 @@ func (p PhaseInfo) Err() *core.ExecutionError {
 	return p.err
 }
 
+func (p PhaseInfo) WithVersion(version uint32) PhaseInfo {
+	return PhaseInfo{
+		phase:   p.phase,
+		version: version,
+		info:    p.info,
+		err:     p.err,
+		reason:  p.reason,
+	}
+}
+
 func (p PhaseInfo) String() string {
 	if p.err != nil {
 		return fmt.Sprintf("Phase<%s:%d Error:%s>", p.phase, p.version, p.err)

--- a/go/tasks/pluginmachinery/k8s/mocks/plugin_context.go
+++ b/go/tasks/pluginmachinery/k8s/mocks/plugin_context.go
@@ -150,6 +150,40 @@ func (_m *PluginContext) OutputWriter() io.OutputWriter {
 	return r0
 }
 
+type PluginContext_PluginStateReader struct {
+	*mock.Call
+}
+
+func (_m PluginContext_PluginStateReader) Return(_a0 core.PluginStateReader) *PluginContext_PluginStateReader {
+	return &PluginContext_PluginStateReader{Call: _m.Call.Return(_a0)}
+}
+
+func (_m *PluginContext) OnPluginStateReader() *PluginContext_PluginStateReader {
+	c_call := _m.On("PluginStateReader")
+	return &PluginContext_PluginStateReader{Call: c_call}
+}
+
+func (_m *PluginContext) OnPluginStateReaderMatch(matchers ...interface{}) *PluginContext_PluginStateReader {
+	c_call := _m.On("PluginStateReader", matchers...)
+	return &PluginContext_PluginStateReader{Call: c_call}
+}
+
+// PluginStateReader provides a mock function with given fields:
+func (_m *PluginContext) PluginStateReader() core.PluginStateReader {
+	ret := _m.Called()
+
+	var r0 core.PluginStateReader
+	if rf, ok := ret.Get(0).(func() core.PluginStateReader); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(core.PluginStateReader)
+		}
+	}
+
+	return r0
+}
+
 type PluginContext_TaskExecutionMetadata struct {
 	*mock.Call
 }

--- a/go/tasks/pluginmachinery/k8s/plugin.go
+++ b/go/tasks/pluginmachinery/k8s/plugin.go
@@ -68,6 +68,16 @@ type PluginContext interface {
 
 	// Returns a handle to the Task's execution metadata.
 	TaskExecutionMetadata() pluginsCore.TaskExecutionMetadata
+
+	// Returns a reader that retrieves previously stored plugin internal state. the state itself is immutable
+	PluginStateReader() pluginsCore.PluginStateReader
+}
+
+// TODO @hamersaw docs
+type PluginState struct {
+	Phase        pluginsCore.Phase
+	PhaseVersion uint32
+	Reason       string
 }
 
 // Defines a simplified interface to author plugins for k8s resources.

--- a/go/tasks/pluginmachinery/k8s/plugin.go
+++ b/go/tasks/pluginmachinery/k8s/plugin.go
@@ -77,11 +77,11 @@ type PluginContext interface {
 // determine if there have been any updates since the previously evaluation.
 type PluginState struct {
 	// Phase is the plugin phase.
-	Phase        pluginsCore.Phase
+	Phase pluginsCore.Phase
 	// PhaseVersion is an number used to indicate reportable changes to state that have the same phase.
 	PhaseVersion uint32
-	// Reason is the message explaning the purpose for being in the reported state.
-	Reason       string
+	// Reason is the message explaining the purpose for being in the reported state.
+	Reason string
 }
 
 // Defines a simplified interface to author plugins for k8s resources.

--- a/go/tasks/pluginmachinery/k8s/plugin.go
+++ b/go/tasks/pluginmachinery/k8s/plugin.go
@@ -73,10 +73,14 @@ type PluginContext interface {
 	PluginStateReader() pluginsCore.PluginStateReader
 }
 
-// TODO @hamersaw docs
+// PluginState defines the state of a k8s plugin. This information must be maintained between propeller evaluations to
+// determine if there have been any updates since the previously evaluation.
 type PluginState struct {
+	// Phase is the plugin phase.
 	Phase        pluginsCore.Phase
+	// PhaseVersion is an number used to indicate reportable changes to state that have the same phase.
 	PhaseVersion uint32
+	// Reason is the message explaning the purpose for being in the reported state.
 	Reason       string
 }
 

--- a/go/tasks/plugins/array/k8s/management_test.go
+++ b/go/tasks/plugins/array/k8s/management_test.go
@@ -129,12 +129,16 @@ func getMockTaskExecutionContext(ctx context.Context, parallelism int) *mocks.Ta
 		ReferenceConstructor:  &storage.URLPathConstructor{},
 	}
 
+	pluginStateReader := &mocks.PluginStateReader{}
+	pluginStateReader.OnGetMatch(mock.Anything).Return(0, nil)
+
 	tCtx := &mocks.TaskExecutionContext{}
 	tCtx.OnTaskReader().Return(tr)
 	tCtx.OnTaskExecutionMetadata().Return(tMeta)
 	tCtx.OnOutputWriter().Return(ow)
 	tCtx.OnInputReader().Return(ir)
 	tCtx.OnDataStore().Return(dataStore)
+	tCtx.OnPluginStateReader().Return(pluginStateReader)
 	return tCtx
 }
 

--- a/go/tasks/plugins/k8s/pod/container_test.go
+++ b/go/tasks/plugins/k8s/pod/container_test.go
@@ -102,6 +102,11 @@ func dummyContainerTaskContext(resources *v1.ResourceRequirements, command []str
 	taskCtx.OnTaskReader().Return(taskReader)
 
 	taskCtx.OnTaskExecutionMetadata().Return(dummyTaskMetadata)
+
+	pluginStateReader := &pluginsCoreMock.PluginStateReader{}
+	pluginStateReader.OnGetMatch(mock.Anything).Return(0, nil)
+	taskCtx.OnPluginStateReader().Return(pluginStateReader)
+
 	return taskCtx
 }
 
@@ -140,6 +145,10 @@ func TestContainerTaskExecutor_BuildResource(t *testing.T) {
 }
 
 func TestContainerTaskExecutor_GetTaskStatus(t *testing.T) {
+	command := []string{"command"}
+	args := []string{"{{.Input}}"}
+	taskCtx := dummyContainerTaskContext(containerResourceRequirements, command, args)
+
 	j := &v1.Pod{
 		Status: v1.PodStatus{},
 	}
@@ -147,21 +156,21 @@ func TestContainerTaskExecutor_GetTaskStatus(t *testing.T) {
 	ctx := context.TODO()
 	t.Run("running", func(t *testing.T) {
 		j.Status.Phase = v1.PodRunning
-		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, nil, j)
+		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, taskCtx, j)
 		assert.NoError(t, err)
 		assert.Equal(t, pluginsCore.PhaseRunning, phaseInfo.Phase())
 	})
 
 	t.Run("queued", func(t *testing.T) {
 		j.Status.Phase = v1.PodPending
-		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, nil, j)
+		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, taskCtx, j)
 		assert.NoError(t, err)
 		assert.Equal(t, pluginsCore.PhaseQueued, phaseInfo.Phase())
 	})
 
 	t.Run("failNoCondition", func(t *testing.T) {
 		j.Status.Phase = v1.PodFailed
-		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, nil, j)
+		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, taskCtx, j)
 		assert.NoError(t, err)
 		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
 		ec := phaseInfo.Err().GetCode()
@@ -177,7 +186,7 @@ func TestContainerTaskExecutor_GetTaskStatus(t *testing.T) {
 				Type: v1.PodReasonUnschedulable,
 			},
 		}
-		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, nil, j)
+		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, taskCtx, j)
 		assert.NoError(t, err)
 		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
 		ec := phaseInfo.Err().GetCode()
@@ -186,7 +195,7 @@ func TestContainerTaskExecutor_GetTaskStatus(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		j.Status.Phase = v1.PodSucceeded
-		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, nil, j)
+		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, taskCtx, j)
 		assert.NoError(t, err)
 		assert.NotNil(t, phaseInfo)
 		assert.Equal(t, pluginsCore.PhaseSuccess, phaseInfo.Phase())
@@ -199,6 +208,10 @@ func TestContainerTaskExecutor_GetProperties(t *testing.T) {
 }
 
 func TestContainerTaskExecutor_GetTaskStatus_InvalidImageName(t *testing.T) {
+	command := []string{"command"}
+	args := []string{"{{.Input}}"}
+	taskCtx := dummyContainerTaskContext(containerResourceRequirements, command, args)
+
 	ctx := context.TODO()
 	reason := "InvalidImageName"
 	message := "Failed to apply default image tag \"TEST/flyteorg/myapp:latest\": couldn't parse image reference" +
@@ -230,7 +243,7 @@ func TestContainerTaskExecutor_GetTaskStatus_InvalidImageName(t *testing.T) {
 
 	t.Run("failInvalidImageName", func(t *testing.T) {
 		pendingPod.Status.Phase = v1.PodPending
-		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, nil, pendingPod)
+		phaseInfo, err := DefaultPodPlugin.GetTaskPhase(ctx, taskCtx, pendingPod)
 		finalReason := fmt.Sprintf("|%s", reason)
 		finalMessage := fmt.Sprintf("|%s", message)
 		assert.NoError(t, err)

--- a/go/tasks/plugins/k8s/pod/plugin.go
+++ b/go/tasks/plugins/k8s/pod/plugin.go
@@ -169,20 +169,15 @@ func (plugin) GetTaskPhaseWithLogs(ctx context.Context, pluginContext k8s.Plugin
 	phaseInfo := pluginsCore.PhaseInfoUndefined
 	switch pod.Status.Phase {
 	case v1.PodSucceeded:
-		//return flytek8s.DemystifySuccess(pod.Status, info)
 		phaseInfo, err = flytek8s.DemystifySuccess(pod.Status, info)
 	case v1.PodFailed:
-		//return flytek8s.DemystifyFailure(pod.Status, info)
 		phaseInfo, err = flytek8s.DemystifyFailure(pod.Status, info)
 	case v1.PodPending:
-		//return flytek8s.DemystifyPending(pod.Status)
 		phaseInfo, err = flytek8s.DemystifyPending(pod.Status)
 	case v1.PodReasonUnschedulable:
-		//return pluginsCore.PhaseInfoQueued(transitionOccurredAt, pluginsCore.DefaultPhaseVersion, "pod unschedulable"), nil
 		phaseInfo = pluginsCore.PhaseInfoQueued(transitionOccurredAt, pluginsCore.DefaultPhaseVersion, "pod unschedulable")
 	case v1.PodUnknown:
-		//return pluginsCore.PhaseInfoUndefined, nil
-		// DO NOTHING
+		phaseInfo = pluginsCore.PhaseInfoUndefined
 	default:
 		primaryContainerName, exists := r.GetAnnotations()[flytek8s.PrimaryContainerKey]
 		if !exists {

--- a/go/tasks/plugins/k8s/pod/plugin.go
+++ b/go/tasks/plugins/k8s/pod/plugin.go
@@ -207,50 +207,13 @@ func (plugin) GetTaskPhaseWithLogs(ctx context.Context, pluginContext k8s.Plugin
 	} else if phaseInfo.Phase() != pluginsCore.PhaseRunning && phaseInfo.Phase() == pluginState.Phase &&
 		phaseInfo.Version() <= pluginState.PhaseVersion && phaseInfo.Reason() != pluginState.Reason {
 
-		// TODO @hamersaw - describe
+		// if we have the same Phase as the previous evaluation and updated the Reason but not the PhaseVersion we must
+		// update the PhaseVersion so an event is sent to reflect the Reason update. this does not handle the Running
+		// Phase because the legacy used `DefaultPhaseVersion + 1` which will only increment to 1.
 		phaseInfo = phaseInfo.WithVersion(pluginState.PhaseVersion)
 	}
 
 	return phaseInfo, err
-
-	/*if err != nil {
-		return pluginsCore.PhaseInfoUndefined, err
-	} else if phaseInfo.Phase() != pluginsCore.PhaseUndefined {
-		// we evaluated one of the previous phases
-		if phaseInfo.Phase() == pluginState.Phase {
-			if phaseInfo.Version() <= pluginState.PhaseVersion && phaseInfo.Reason() != pluginState.Reason {
-				// if we executed one of the previous phases and the Reason has changed and the PhaseVersion has not
-				// we need to increment the PhaseVersion so that the updated Reason is sent to admin
-				phaseInfo = phaseInfo.WithVersion(pluginState.PhaseVersion+1)
-			} else {
-				// to stop an event from being sent - we ensure the version is the same
-				phaseInfo = phaseInfo.WithVersion(pluginState.PhaseVersion)
-			}
-		}
-
-		return phaseInfo, err
-	}*/
-
-	// TODO @hamersaw - unable to detect reason updates to "RUNNING" state unless we also track changes to logs
-	// because DefaultPhaseVersion+1 will only increment to 1, if we use previousVersion+1 then we will always send an event
-
-	/*primaryContainerName, exists := r.GetAnnotations()[flytek8s.PrimaryContainerKey]
-	if !exists {
-		// if the primary container annotation dos not exist, then the task requires all containers
-		// to succeed to declare success. therefore, if the pod is not in one of the above states we
-		// fallback to declaring the task as 'running'.
-		if len(info.Logs) > 0 {
-			return pluginsCore.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion+1, &info), nil
-		}
-		return pluginsCore.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, &info), nil
-	}
-
-	// if the primary container annotation exists, we use the status of the specified container
-	primaryContainerPhase := flytek8s.DeterminePrimaryContainerPhase(primaryContainerName, pod.Status.ContainerStatuses, &info)
-	if primaryContainerPhase.Phase() == pluginsCore.PhaseRunning && len(info.Logs) > 0 {
-		return pluginsCore.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion+1, primaryContainerPhase.Info()), nil
-	}
-	return primaryContainerPhase, nil*/
 }
 
 func (plugin) GetProperties() k8s.PluginProperties {

--- a/go/tasks/plugins/k8s/pod/plugin.go
+++ b/go/tasks/plugins/k8s/pod/plugin.go
@@ -205,7 +205,7 @@ func (plugin) GetTaskPhaseWithLogs(ctx context.Context, pluginContext k8s.Plugin
 		// if we have the same Phase as the previous evaluation and updated the Reason but not the PhaseVersion we must
 		// update the PhaseVersion so an event is sent to reflect the Reason update. this does not handle the Running
 		// Phase because the legacy used `DefaultPhaseVersion + 1` which will only increment to 1.
-		phaseInfo = phaseInfo.WithVersion(pluginState.PhaseVersion)
+		phaseInfo = phaseInfo.WithVersion(pluginState.PhaseVersion + 1)
 	}
 
 	return phaseInfo, err

--- a/go/tasks/plugins/k8s/pod/plugin.go
+++ b/go/tasks/plugins/k8s/pod/plugin.go
@@ -177,7 +177,7 @@ func (plugin) GetTaskPhaseWithLogs(ctx context.Context, pluginContext k8s.Plugin
 	case v1.PodReasonUnschedulable:
 		phaseInfo = pluginsCore.PhaseInfoQueued(transitionOccurredAt, pluginsCore.DefaultPhaseVersion, "pod unschedulable")
 	case v1.PodUnknown:
-		phaseInfo = pluginsCore.PhaseInfoUndefined
+		// DO NOTHING
 	default:
 		primaryContainerName, exists := r.GetAnnotations()[flytek8s.PrimaryContainerKey]
 		if !exists {

--- a/go/tasks/plugins/k8s/pod/plugin.go
+++ b/go/tasks/plugins/k8s/pod/plugin.go
@@ -191,15 +191,13 @@ func (plugin) GetTaskPhaseWithLogs(ctx context.Context, pluginContext k8s.Plugin
 			// fallback to declaring the task as 'running'.
 			phaseInfo = pluginsCore.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, &info)
 			if len(info.Logs) > 0 {
-				//return pluginsCore.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion+1, &info), nil
-				phaseInfo = phaseInfo.WithVersion(pluginsCore.DefaultPhaseVersion+1)
+				phaseInfo = phaseInfo.WithVersion(pluginsCore.DefaultPhaseVersion + 1)
 			}
 		} else {
 			// if the primary container annotation exists, we use the status of the specified container
 			phaseInfo = flytek8s.DeterminePrimaryContainerPhase(primaryContainerName, pod.Status.ContainerStatuses, &info)
 			if phaseInfo.Phase() == pluginsCore.PhaseRunning && len(info.Logs) > 0 {
-				//return pluginsCore.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion+1, primaryContainerPhase.Info()), nil
-				phaseInfo = phaseInfo.WithVersion(pluginsCore.DefaultPhaseVersion+1)
+				phaseInfo = phaseInfo.WithVersion(pluginsCore.DefaultPhaseVersion + 1)
 			}
 		}
 	}
@@ -209,6 +207,7 @@ func (plugin) GetTaskPhaseWithLogs(ctx context.Context, pluginContext k8s.Plugin
 	} else if phaseInfo.Phase() != pluginsCore.PhaseRunning && phaseInfo.Phase() == pluginState.Phase &&
 		phaseInfo.Version() <= pluginState.PhaseVersion && phaseInfo.Reason() != pluginState.Reason {
 
+		// TODO @hamersaw - describe
 		phaseInfo = phaseInfo.WithVersion(pluginState.PhaseVersion)
 	}
 

--- a/go/tasks/plugins/k8s/pod/sidecar_test.go
+++ b/go/tasks/plugins/k8s/pod/sidecar_test.go
@@ -120,6 +120,10 @@ func getDummySidecarTaskContext(taskTemplate *core.TaskTemplate, resources *v1.R
 
 	taskCtx.OnTaskExecutionMetadata().Return(dummyTaskMetadata)
 
+	pluginStateReader := &pluginsCoreMock.PluginStateReader{}
+	pluginStateReader.OnGetMatch(mock.Anything).Return(0, nil)
+	taskCtx.OnPluginStateReader().Return(pluginStateReader)
+
 	return taskCtx
 }
 


### PR DESCRIPTION
# TL;DR
This PR adds support for persisting state of k8s plugins including Phase, PhaseVersion, and Reason. This is used to detect scenarios where the `Reason` has been updated and update the `PhaseVersion` to ensure that the latest `Reason` is reported to FlyteAdmin in a `TaskExecutionEvent`.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3440

## Follow-up issue
_NA_
