### PR TITLE
Inject container resource during BuildRawContainer

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/container_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper.go
@@ -205,7 +205,6 @@ func BuildRawContainer(ctx context.Context, taskContainer *core.Container, taskE
 	}
 
 	res, err := ToK8sResourceRequirements(taskContainer.Resources)
-
 	if err != nil {
 		return nil, err
 	}
@@ -258,7 +257,7 @@ func ToK8sContainer(ctx context.Context, tCtx pluginscore.TaskExecutionContext) 
 		Task:             tCtx.TaskReader(),
 	}
 
-	if err := AddFlyteCustomizationsToContainer(ctx, templateParameters, ResourceCustomizationModeAssignResources, container); err != nil {
+	if err := AddFlyteCustomizationsToContainer(ctx, templateParameters, ResourceCustomizationModeMergeExistingResources, container); err != nil {
 		return nil, err
 	}
 
@@ -310,7 +309,9 @@ func AddFlyteCustomizationsToContainer(ctx context.Context, parameters template.
 			" Resources [%v] with mode [%v]", res, platformResources, container.Resources, mode)
 
 		switch mode {
-		case ResourceCustomizationModeAssignResources, ResourceCustomizationModeMergeExistingResources:
+		case ResourceCustomizationModeAssignResources:
+			container.Resources = ApplyResourceOverrides(*res, *platformResources, assignIfUnset)
+		case ResourceCustomizationModeMergeExistingResources:
 			MergeResources(*res, &container.Resources)
 			container.Resources = ApplyResourceOverrides(container.Resources, *platformResources, assignIfUnset)
 		case ResourceCustomizationModeEnsureExistingResourcesInRange:


### PR DESCRIPTION

# TL;DR

Inject container resource during BuildRawContainer


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_
### Describe the bug

Note: This bug does not affect the behavior of Flyte, but the logic contains a flaw.

In [BuildRawContainer](https://github.com/flyteorg/flyteplugins/blob/master/go/tasks/pluginmachinery/flytek8s/container_helper.go#L213), we do not inject the container resource from the  task template. Instead, we inject the resource from [parameters.TaskExecMetadata.GetOverrides().GetResources()](https://github.com/flyteorg/flytepropeller/blob/master/pkg/compiler/transformers/k8s/node.go#L49).

This is because for both `_with_override(resource=...` and `@task(requests=...)`, they are both inject as the node resource override in [buildNodeSpec](https://github.com/flyteorg/flytepropeller/blob/master/pkg/compiler/transformers/k8s/node.go#L49)

### Expected behavior

For the case of `@task(requests=...)`, the resource override on the node should be empty, and the resource is injected from tasktemplate at [BuildRawContainer](https://github.com/flyteorg/flyteplugins/blob/master/go/tasks/pluginmachinery/flytek8s/container_helper.go#L213)

## Tracking Issue

https://github.com/flyteorg/flyte/issues/3540

