### PR TITLE
Deprecated TransitionTypeBarrier

### DIFF
--- a/go/tasks/pluginmachinery/core/transition.go
+++ b/go/tasks/pluginmachinery/core/transition.go
@@ -11,6 +11,7 @@ const (
 	// The transition is eventually consistent. For all the state written may not be visible in the next call, but eventually will persist
 	// Best to use when the plugin logic is completely idempotent. This is also the most performant option.
 	TransitionTypeEphemeral TransitionType = iota
+	// @deprecated support for Barrier type transitions has been deprecated
 	// This transition tries its best to make the latest state visible for every consecutive read. But, it is possible
 	// to go back in time, i.e. monotonic consistency is violated (in rare cases).
 	TransitionTypeBarrier

--- a/go/tasks/pluginmachinery/internal/webapi/core.go
+++ b/go/tasks/pluginmachinery/internal/webapi/core.go
@@ -97,7 +97,7 @@ func (c CorePlugin) Handle(ctx context.Context, tCtx core.TaskExecutionContext) 
 		return core.UnknownTransition, err
 	}
 
-	return core.DoTransitionType(core.TransitionTypeBarrier, phaseInfo), nil
+	return core.DoTransition(phaseInfo), nil
 }
 
 func (c CorePlugin) Abort(ctx context.Context, tCtx core.TaskExecutionContext) error {

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -148,7 +148,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		return core.UnknownTransition, err
 	}
 
-	return core.DoTransitionType(core.TransitionTypeBarrier, phaseInfo), nil
+	return core.DoTransition(phaseInfo), nil
 }
 
 func (e Executor) Abort(ctx context.Context, tCtx core.TaskExecutionContext) error {

--- a/go/tasks/plugins/hive/executor.go
+++ b/go/tasks/plugins/hive/executor.go
@@ -65,7 +65,7 @@ func (q QuboleHiveExecutor) Handle(ctx context.Context, tCtx core.TaskExecutionC
 		return core.UnknownTransition, err
 	}
 
-	return core.DoTransitionType(core.TransitionTypeBarrier, phaseInfo), nil
+	return core.DoTransition(phaseInfo), nil
 }
 
 func (q QuboleHiveExecutor) Abort(ctx context.Context, tCtx core.TaskExecutionContext) error {

--- a/go/tasks/plugins/presto/executor.go
+++ b/go/tasks/plugins/presto/executor.go
@@ -63,7 +63,7 @@ func (p Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		return core.UnknownTransition, err
 	}
 
-	return core.DoTransitionType(core.TransitionTypeBarrier, phaseInfo), nil
+	return core.DoTransition(phaseInfo), nil
 }
 
 func (p Executor) Abort(ctx context.Context, tCtx core.TaskExecutionContext) error {

--- a/tests/end_to_end.go
+++ b/tests/end_to_end.go
@@ -252,7 +252,7 @@ func RunPluginEndToEndTest(t *testing.T, executor pluginCore.Plugin, template *i
 	tCtx.OnMaxDatasetSizeBytes().Return(1000000)
 	tCtx.OnSecretManager().Return(secretManager)
 
-	trns := pluginCore.DoTransitionType(pluginCore.TransitionTypeBarrier, pluginCore.PhaseInfoQueued(time.Now(), 0, ""))
+	trns := pluginCore.DoTransition(pluginCore.PhaseInfoQueued(time.Now(), 0, ""))
 	for !trns.Info().Phase().IsTerminal() {
 		trns, err = executor.Handle(ctx, tCtx)
 		assert.NoError(t, err)


### PR DESCRIPTION
# TL;DR
This PR deprecates `TransitionTypeBarrier` in support of removing support for `BarrierTicks` in FlytePropeller.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3544

## Follow-up issue
_NA_
