### PR TITLE
Mocking plugin state reader in maptask

### DIFF
--- a/go/tasks/plugins/array/k8s/subtask_exec_context.go
+++ b/go/tasks/plugins/array/k8s/subtask_exec_context.go
@@ -50,6 +50,23 @@ func (s SubTaskExecutionContext) TaskReader() pluginsCore.TaskReader {
 	return s.subtaskReader
 }
 
+// pluginStateReader overrides the default PluginStateReader because the maptask does not persist
+// state between task evaluations.
+type pluginStateReader struct{}
+
+func (p pluginStateReader) GetStateVersion() uint8 {
+	return 0
+}
+
+func (p pluginStateReader) Get(t interface{}) (stateVersion uint8, err error) {
+	return 0, nil
+}
+
+// PluginStateReader overrides the default behavior to return a custom pluginStateReader.
+func (s SubTaskExecutionContext) PluginStateReader() pluginsCore.PluginStateReader {
+	return pluginStateReader{}
+}
+
 // NewSubtaskExecutionContext constructs a SubTaskExecutionContext using the provided parameters
 func NewSubTaskExecutionContext(ctx context.Context, tCtx pluginsCore.TaskExecutionContext, taskTemplate *core.TaskTemplate,
 	executionIndex, originalIndex int, retryAttempt uint64, systemFailures uint64) (SubTaskExecutionContext, error) {


### PR DESCRIPTION
# TL;DR
Since the [k8s plugin persistence PR](https://github.com/flyteorg/flyteplugins/pull/331) the pod plugin expects a `PluginStateReader` that provides the latest plugin state. The maptask did not properly override this field on the `TaskExecutionContext` and therefore failed during execution. This PR mocks the `PluginStateReader` with a nil object which does nothing.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
