### PR TITLE
Use dask cuda worker when GPU resource > 0

### DIFF
--- a/go/tasks/plugins/k8s/dask/dask.go
+++ b/go/tasks/plugins/k8s/dask/dask.go
@@ -187,6 +187,12 @@ func createWorkerSpec(cluster plugins.DaskWorkerGroup, defaults defaults) (*dask
 			memory := limits.Memory().String()
 			workerArgs = append(workerArgs, "--memory-limit", memory)
 		}
+		// If limits includes gpu, assume dask cuda worker cli startup
+		// https://docs.rapids.ai/api/dask-cuda/nightly/quickstart.html#dask-cuda-worker
+		// TODO: is this how gpu resources are called?
+		if limits.Gpu() != nil {
+			workerArgs[0] = "dask cuda worker"
+		}
 	}
 
 	wokerSpec := v1.PodSpec{

--- a/go/tasks/plugins/k8s/dask/dask.go
+++ b/go/tasks/plugins/k8s/dask/dask.go
@@ -189,9 +189,8 @@ func createWorkerSpec(cluster plugins.DaskWorkerGroup, defaults defaults) (*dask
 		}
 		// If limits includes gpu, assume dask cuda worker cli startup
 		// https://docs.rapids.ai/api/dask-cuda/nightly/quickstart.html#dask-cuda-worker
-		// TODO: is this how gpu resources are called?
-		if limits.Gpu() != nil {
-			workerArgs[0] = "dask cuda worker"
+		if !limits.Name(flytek8s.ResourceNvidiaGPU, "0").IsZero() {
+			workerArgs[0] = "dask-cuda-worker"
 		}
 	}
 


### PR DESCRIPTION
# TL;DR
If a gpu has been specified in the dask plugin resource, assume we want to use `dask cuda worker` i.e. that dask-cuda is present on the specified image.

## Type
 - [x] Feature
 - [x] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Currently we build an arg to submit to the container and inject values such as threads and memory from the limits specified in the resources object in the dask plugin object. [Dask cuda](https://github.com/rapidsai/dask-cuda) gives us many built in gpu tools and all that is required is to ensure dask cuda is installed and then to start out workers with `dask-cuda-worker`. So, in order to accomodate, we simply check for gpu limits in the dask plugin resources and overwrite the first arg to `dask-cuda-worker`.