### PR TITLE
Pass `worker_spec_command` to mpi plugin to support horovod

### DIFF
--- a/go/tasks/plugins/k8s/kfoperators/mpi/mpi.go
+++ b/go/tasks/plugins/k8s/kfoperators/mpi/mpi.go
@@ -72,6 +72,9 @@ func (mpiOperatorResourceHandler) BuildResource(ctx context.Context, taskCtx plu
 
 	// workersPodSpec is deepCopy of podSpec submitted by flyte
 	workersPodSpec := podSpec.DeepCopy()
+
+	// If users don't specify "worker_spec_command" in the task config, the command/args are empty.
+	// In the case of horovod tasks, each worker runs a command launching ssh daemon.
 	workerSpecCommand := []string{}
 	if val, ok := taskTemplateConfig["worker_spec_command"]; ok {
 		workerSpecCommand = strings.Split(val, " ")

--- a/go/tasks/plugins/k8s/kfoperators/mpi/mpi.go
+++ b/go/tasks/plugins/k8s/kfoperators/mpi/mpi.go
@@ -74,7 +74,9 @@ func (mpiOperatorResourceHandler) BuildResource(ctx context.Context, taskCtx plu
 	workersPodSpec := podSpec.DeepCopy()
 
 	// If users don't specify "worker_spec_command" in the task config, the command/args are empty.
-	// In the case of horovod tasks, each worker runs a command launching ssh daemon.
+	// However, in some cases, the workers need command/args.
+	// For example, in horovod tasks, each worker runs a command launching ssh daemon.
+
 	workerSpecCommand := []string{}
 	if val, ok := taskTemplateConfig["worker_spec_command"]; ok {
 		workerSpecCommand = strings.Split(val, " ")

--- a/go/tasks/plugins/k8s/kfoperators/mpi/mpi.go
+++ b/go/tasks/plugins/k8s/kfoperators/mpi/mpi.go
@@ -22,6 +22,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const workerSpecCommandKey = "worker_spec_command"
+
 type mpiOperatorResourceHandler struct {
 }
 
@@ -78,7 +80,7 @@ func (mpiOperatorResourceHandler) BuildResource(ctx context.Context, taskCtx plu
 	// For example, in horovod tasks, each worker runs a command launching ssh daemon.
 
 	workerSpecCommand := []string{}
-	if val, ok := taskTemplateConfig["worker_spec_command"]; ok {
+	if val, ok := taskTemplateConfig[workerSpecCommandKey]; ok {
 		workerSpecCommand = strings.Split(val, " ")
 	}
 


### PR DESCRIPTION
# TL;DR
Pass `worker_spec_command` to mpi plugin to support horovod task

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
In this pr in flytekit, we pass `worker_spec_command` to backend to be run on worker pod.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/3567
