### PR TITLE
Fix double http in the Spark Driver UI Link

### DIFF
--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -407,7 +407,7 @@ func getEventInfoForSpark(sj *sparkOp.SparkApplication) (*pluginsCore.TaskInfo, 
 			})
 		}
 	} else if sj.Status.AppState.State == sparkOp.RunningState && sj.Status.DriverInfo.WebUIIngressAddress != "" {
-		// Older versions of spark-operator does not append http:// but newer versions do. 
+		// Older versions of spark-operator does not append http:// but newer versions do.
 		uri := strings.TrimPrefix(sj.Status.DriverInfo.WebUIIngressAddress, "http://")
 		customInfoMap[sparkDriverUI] = fmt.Sprintf("https://%s", uri)
 		// Custom doesn't work unless the UI has a custom plugin to parse this, hence add to Logs as well.

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -407,8 +407,9 @@ func getEventInfoForSpark(sj *sparkOp.SparkApplication) (*pluginsCore.TaskInfo, 
 			})
 		}
 	} else if sj.Status.AppState.State == sparkOp.RunningState && sj.Status.DriverInfo.WebUIIngressAddress != "" {
-		// Append https as the operator doesn't currently.
-		customInfoMap[sparkDriverUI] = fmt.Sprintf("https://%s", sj.Status.DriverInfo.WebUIIngressAddress)
+		// Older versions of spark-operator does not have http:// but newer versions have. 
+		customInfoMap[sparkDriverUI] = strings.TrimPrefix(sj.Status.DriverInfo.WebUIIngressAddress, "http://")
+		customInfoMap[sparkDriverUI] = fmt.Sprintf("https://%s", customInfoMap[sparkDriverUI])
 		// Custom doesn't work unless the UI has a custom plugin to parse this, hence add to Logs as well.
 		taskLogs = append(taskLogs, &core.TaskLog{
 			Uri:           customInfoMap[sparkDriverUI],

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -407,7 +407,7 @@ func getEventInfoForSpark(sj *sparkOp.SparkApplication) (*pluginsCore.TaskInfo, 
 			})
 		}
 	} else if sj.Status.AppState.State == sparkOp.RunningState && sj.Status.DriverInfo.WebUIIngressAddress != "" {
-		// Older versions of spark-operator does not have http:// but newer versions have. 
+		// Older versions of spark-operator does not append http:// but newer versions do. 
 		uri := strings.TrimPrefix(sj.Status.DriverInfo.WebUIIngressAddress, "http://")
 		customInfoMap[sparkDriverUI] = fmt.Sprintf("https://%s", uri)
 		// Custom doesn't work unless the UI has a custom plugin to parse this, hence add to Logs as well.

--- a/go/tasks/plugins/k8s/spark/spark.go
+++ b/go/tasks/plugins/k8s/spark/spark.go
@@ -408,8 +408,8 @@ func getEventInfoForSpark(sj *sparkOp.SparkApplication) (*pluginsCore.TaskInfo, 
 		}
 	} else if sj.Status.AppState.State == sparkOp.RunningState && sj.Status.DriverInfo.WebUIIngressAddress != "" {
 		// Older versions of spark-operator does not have http:// but newer versions have. 
-		customInfoMap[sparkDriverUI] = strings.TrimPrefix(sj.Status.DriverInfo.WebUIIngressAddress, "http://")
-		customInfoMap[sparkDriverUI] = fmt.Sprintf("https://%s", customInfoMap[sparkDriverUI])
+		uri := strings.TrimPrefix(sj.Status.DriverInfo.WebUIIngressAddress, "http://")
+		customInfoMap[sparkDriverUI] = fmt.Sprintf("https://%s", uri)
 		// Custom doesn't work unless the UI has a custom plugin to parse this, hence add to Logs as well.
 		taskLogs = append(taskLogs, &core.TaskLog{
 			Uri:           customInfoMap[sparkDriverUI],

--- a/go/tasks/plugins/k8s/spark/spark_test.go
+++ b/go/tasks/plugins/k8s/spark/spark_test.go
@@ -2,7 +2,6 @@ package spark
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strconv"
 	"testing"
@@ -34,7 +33,7 @@ import (
 const sparkMainClass = "MainClass"
 const sparkApplicationFile = "local:///spark_app.py"
 const testImage = "image://"
-const sparkUIAddress = "spark-ui.flyte"
+const sparkUIAddress = "http://spark-ui.flyte"
 
 var (
 	dummySparkConf = map[string]string{
@@ -91,7 +90,7 @@ func TestGetEventInfo(t *testing.T) {
 	info, err := getEventInfoForSpark(dummySparkApplication(sj.RunningState))
 	assert.NoError(t, err)
 	assert.Len(t, info.Logs, 6)
-	assert.Equal(t, fmt.Sprintf("https://%s", sparkUIAddress), info.CustomInfo.Fields[sparkDriverUI].GetStringValue())
+	assert.Equal(t, "https://spark-ui.flyte", info.CustomInfo.Fields[sparkDriverUI].GetStringValue())
 	generatedLinks := make([]string, 0, len(info.Logs))
 	for _, l := range info.Logs {
 		generatedLinks = append(generatedLinks, l.Uri)


### PR DESCRIPTION
Fixes https://github.com/flyteorg/flyte/issues/3623

Spark operator code: https://github.com/GoogleCloudPlatform/spark-on-k8s-operator/blob/5f2efd4ff97e7c0bfdb726a066118d3401576730/pkg/controller/sparkapplication/sparkui.go#L57

This change solves the problem by keeping Flyte compatible with older version of Spark Operator.
Another, simpler implentation is to just pass whatever spark operator gives. Browsers will add https automatically? 