### PR TITLE
Only initializing maptask if there is no failure

### DIFF
--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -89,7 +89,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		nextState, err = array.DetermineDiscoverability(ctx, tCtx, pluginConfig.MaxArrayJobSize, pluginState)
 
 		nextPhase, _ := nextState.GetPhase()
-		if err == nil && nextPhase != arrayCore.PhaseStart {
+		if err == nil && nextPhase != arrayCore.PhaseStart && nextPhase != arrayCore.PhasePermanentFailure {
 			// we wait to transition out of PhaseStart to InitializeExternalResources because then the array
 			// job configuration has then been validated and all of the metadata necessary to report subtask
 			// status (ie. cache hit / etc) is available.


### PR DESCRIPTION
# TL;DR
Checking state to ensure that the `DetermineDiscoverability` function does not fail before attempting to initialize `ExternalResources` for the maptask subtasks.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
fixes https://github.com/flyteorg/flyte/issues/3709

## Follow-up issue
_NA_
