### PR TITLE
Improve demystifying GKE spot node preemtion #patch

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/pod_helper.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper.go
@@ -622,7 +622,9 @@ func DemystifyFailure(status v1.PodStatus, info pluginsCore.TaskInfo) (pluginsCo
 	//         startTime: "2022-01-30T14:24:07Z"
 	//     }
 	// }
-	if code == "Shutdown" {
+	//
+	// In some versions of GKE the reason can also be "Terminated"
+	if code == "Shutdown" || code == "Terminated" {
 		return pluginsCore.PhaseInfoSystemRetryableFailure(Interrupted, message, &info), nil
 	}
 

--- a/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/pod_helper_test.go
@@ -900,6 +900,17 @@ func TestDemystifyFailure(t *testing.T) {
 		assert.Equal(t, "Interrupted", phaseInfo.Err().Code)
 		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().Kind)
 	})
+
+	t.Run("GKE kubelet graceful node shutdown", func(t *testing.T) {
+		phaseInfo, err := DemystifyFailure(v1.PodStatus{
+			Message: "Foobar",
+			Reason:  "Terminated",
+		}, pluginsCore.TaskInfo{})
+		assert.Nil(t, err)
+		assert.Equal(t, pluginsCore.PhaseRetryableFailure, phaseInfo.Phase())
+		assert.Equal(t, "Interrupted", phaseInfo.Err().Code)
+		assert.Equal(t, core.ExecutionError_SYSTEM, phaseInfo.Err().Kind)
+	})
 }
 
 func TestDemystifyPending_testcases(t *testing.T) {


### PR DESCRIPTION
# TL;DR
Fixes a bug where propeller would incorrectly label spot node preemption as user error 

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
We've had a lot of issues recently where tasks running on spot instances would not be re-scheduled onto regular instances after they've been preempted by GKE.

We've been able to consistently replicate this by: 
1. Starting an interruptible task with some retries
2. As soon as it's up, going to the VM instances page and Stopping (not deleting) the instance. According to the [Google Cloud docs](https://cloud.google.com/compute/docs/instances/spot#preemption-process) this is the same as preemption

Doing this, non of the retry attempts have been scheduled onto non-spot instances.

I've debugged this by running a local instance of `flytepropeller` with a local version of `flyteplugins`. I've used this instance instead of the one usually running in our cluster. I then set a breakpoint here:

https://github.com/flyteorg/flyteplugins/blob/8a2f8ca2e723d067c4915b8a9ec2960eb4ff6526/go/tasks/pluginmachinery/flytek8s/pod_helper.go#L625 

And could see that the code is `"Terminated"` instead of `"Shutdown"`. Once I've added `"Terminated"` things worked as expected
