### PR TITLE
Fix initial dask job state

### DIFF
--- a/go/tasks/plugins/k8s/dask/dask.go
+++ b/go/tasks/plugins/k8s/dask/dask.go
@@ -320,7 +320,10 @@ func (p daskResourceHandler) GetTaskPhase(ctx context.Context, pluginContext k8s
 		OccurredAt: &occurredAt,
 	}
 
-	isQueued := status == daskAPI.DaskJobCreated ||
+	// There is a short period between the `DaskJob` resource being created and `Status.JobStatus` being set by the `dask-operator`. 
+	// In that period, the `JobStatus` will be an empty string. We're treating this as Initializing/Queuing.
+	isQueued := status == "" ||
+		status == daskAPI.DaskJobCreated ||
 		status == daskAPI.DaskJobClusterCreated
 
 	if !isQueued {
@@ -337,6 +340,8 @@ func (p daskResourceHandler) GetTaskPhase(ctx context.Context, pluginContext k8s
 	}
 
 	switch status {
+	case "":
+		return pluginsCore.PhaseInfoInitializing(occurredAt, pluginsCore.DefaultPhaseVersion, "unknown", &info), nil
 	case daskAPI.DaskJobCreated:
 		return pluginsCore.PhaseInfoInitializing(occurredAt, pluginsCore.DefaultPhaseVersion, "job created", &info), nil
 	case daskAPI.DaskJobClusterCreated:

--- a/go/tasks/plugins/k8s/dask/dask.go
+++ b/go/tasks/plugins/k8s/dask/dask.go
@@ -320,7 +320,7 @@ func (p daskResourceHandler) GetTaskPhase(ctx context.Context, pluginContext k8s
 		OccurredAt: &occurredAt,
 	}
 
-	// There is a short period between the `DaskJob` resource being created and `Status.JobStatus` being set by the `dask-operator`. 
+	// There is a short period between the `DaskJob` resource being created and `Status.JobStatus` being set by the `dask-operator`.
 	// In that period, the `JobStatus` will be an empty string. We're treating this as Initializing/Queuing.
 	isQueued := status == "" ||
 		status == daskAPI.DaskJobCreated ||

--- a/go/tasks/plugins/k8s/dask/dask_test.go
+++ b/go/tasks/plugins/k8s/dask/dask_test.go
@@ -491,7 +491,14 @@ func TestGetTaskPhaseDask(t *testing.T) {
 	daskResourceHandler := daskResourceHandler{}
 	ctx := context.TODO()
 
-	taskPhase, err := daskResourceHandler.GetTaskPhase(ctx, nil, dummyDaskJob(daskAPI.DaskJobCreated))
+	taskPhase, err := daskResourceHandler.GetTaskPhase(ctx, nil, dummyDaskJob(""))
+	assert.NoError(t, err)
+	assert.Equal(t, taskPhase.Phase(), pluginsCore.PhaseInitializing)
+	assert.NotNil(t, taskPhase.Info())
+	assert.Nil(t, taskPhase.Info().Logs)
+	assert.Nil(t, err)
+
+	taskPhase, err = daskResourceHandler.GetTaskPhase(ctx, nil, dummyDaskJob(daskAPI.DaskJobCreated))
 	assert.NoError(t, err)
 	assert.Equal(t, taskPhase.Phase(), pluginsCore.PhaseInitializing)
 	assert.NotNil(t, taskPhase.Info())


### PR DESCRIPTION
# TL;DR
When the `dask` plugin creates a `DaskJob` k8s resource, it will initially not have the `.Status.JobStatus` property set. 

So 
https://github.com/flyteorg/flyteplugins/blob/de1d1d345f3bf487701b1f732b2c56f76e81e086/go/tasks/plugins/k8s/dask/dask.go#L316
will return an empty string until the `DaskOperator` sets the status for the first time. While this period is very brief, we've seen it happening a few times.

This PR adds support for the `""` state, effectively handling it the same as being queued/initializing.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
