### PR TITLE
fix v1 pytorch job plugin with elastic policy

### DIFF
--- a/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
+++ b/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
@@ -88,10 +88,7 @@ func (pytorchOperatorResourceHandler) BuildResource(ctx context.Context, taskCtx
 		// Set elastic config
 		elasticConfig := pytorchTaskExtraArgs.GetElasticConfig()
 		if elasticConfig != nil {
-			elasticPolicy, err = ParseElasticConfig(elasticConfig)
-			if err != nil {
-				return nil, err
-			}
+			elasticPolicy = ParseElasticConfig(elasticConfig)
 		}
 	} else if taskTemplate.TaskTypeVersion == 1 {
 		kfPytorchTaskExtraArgs := kfplugins.DistributedPyTorchTrainingTask{}
@@ -140,10 +137,7 @@ func (pytorchOperatorResourceHandler) BuildResource(ctx context.Context, taskCtx
 		// Set elastic config
 		elasticConfig := kfPytorchTaskExtraArgs.GetElasticConfig()
 		if elasticConfig != nil {
-			elasticPolicy, err = ParseElasticConfig(elasticConfig)
-			if err != nil {
-				return nil, err
-			}
+			elasticPolicy = ParseElasticConfig(elasticConfig)
 		}
 	} else {
 		return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification,
@@ -203,7 +197,7 @@ type ElasticConfig interface {
 }
 
 // To support parsing elastic config from both v0 and v1 of kubeflow pytorch idl
-func ParseElasticConfig(elasticConfig ElasticConfig) (*kubeflowv1.ElasticPolicy, error) {
+func ParseElasticConfig(elasticConfig ElasticConfig) *kubeflowv1.ElasticPolicy {
 	minReplicas := elasticConfig.GetMinReplicas()
 	maxReplicas := elasticConfig.GetMaxReplicas()
 	nProcPerNode := elasticConfig.GetNprocPerNode()
@@ -215,7 +209,7 @@ func ParseElasticConfig(elasticConfig ElasticConfig) (*kubeflowv1.ElasticPolicy,
 		RDZVBackend:  &rdzvBackend,
 		NProcPerNode: &nProcPerNode,
 		MaxRestarts:  &maxRestarts,
-	}, nil
+	}
 }
 
 // Analyses the k8s resource and reports the status as TaskPhase. This call is expected to be relatively fast,

--- a/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
+++ b/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
@@ -638,3 +638,41 @@ func TestBuildResourcePytorchV1WithOnlyWorkerSpec(t *testing.T) {
 
 	assert.Nil(t, pytorchJob.Spec.ElasticPolicy)
 }
+
+func TestBuildResourcePytorchV2WithElastic(t *testing.T) {
+	taskConfig := &kfplugins.DistributedPyTorchTrainingTask{
+		WorkerReplicas: &kfplugins.DistributedPyTorchTrainingReplicaSpec{
+			Replicas: 2,
+		},
+		ElasticConfig: &kfplugins.ElasticConfig{MinReplicas: 1, MaxReplicas: 2, NprocPerNode: 4, RdzvBackend: "c10d"},
+	}
+	taskTemplate := dummyPytorchTaskTemplate("job5", taskConfig)
+	taskTemplate.TaskTypeVersion = 1
+
+	pytorchResourceHandler := pytorchOperatorResourceHandler{}
+	resource, err := pytorchResourceHandler.BuildResource(context.TODO(), dummyPytorchTaskContext(taskTemplate))
+	assert.NoError(t, err)
+	assert.NotNil(t, resource)
+
+	pytorchJob, ok := resource.(*kubeflowv1.PyTorchJob)
+	assert.True(t, ok)
+	assert.Equal(t, int32(2), *pytorchJob.Spec.PyTorchReplicaSpecs[kubeflowv1.PyTorchJobReplicaTypeWorker].Replicas)
+	assert.NotNil(t, pytorchJob.Spec.ElasticPolicy)
+	assert.Equal(t, int32(1), *pytorchJob.Spec.ElasticPolicy.MinReplicas)
+	assert.Equal(t, int32(2), *pytorchJob.Spec.ElasticPolicy.MaxReplicas)
+	assert.Equal(t, int32(4), *pytorchJob.Spec.ElasticPolicy.NProcPerNode)
+	assert.Equal(t, kubeflowv1.RDZVBackend("c10d"), *pytorchJob.Spec.ElasticPolicy.RDZVBackend)
+
+	assert.Equal(t, 1, len(pytorchJob.Spec.PyTorchReplicaSpecs))
+	assert.Contains(t, pytorchJob.Spec.PyTorchReplicaSpecs, kubeflowv1.PyTorchJobReplicaTypeWorker)
+
+	var hasContainerWithDefaultPytorchName = false
+
+	for _, container := range pytorchJob.Spec.PyTorchReplicaSpecs[kubeflowv1.PyTorchJobReplicaTypeWorker].Template.Spec.Containers {
+		if container.Name == kubeflowv1.PytorchJobDefaultContainerName {
+			hasContainerWithDefaultPytorchName = true
+		}
+	}
+
+	assert.True(t, hasContainerWithDefaultPytorchName)
+}


### PR DESCRIPTION
# TL;DR
There was a bug that introduced in PR #345. The pytorch v2 task template is handled incorrectly.
Added Elastic Config parsing for v1. It follows the exact same handling logic as v0 since they are kept as same as v0.

Follow-up PR in flytekit: PR [#1690](https://github.com/flyteorg/flytekit/pull/1690)

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

