### PR TITLE
Set scheduler restart policy to `Always`

### DIFF
--- a/go/tasks/plugins/k8s/dask/dask.go
+++ b/go/tasks/plugins/k8s/dask/dask.go
@@ -237,7 +237,7 @@ func createSchedulerSpec(cluster plugins.DaskScheduler, clusterName string, defa
 
 	return &daskAPI.SchedulerSpec{
 		Spec: v1.PodSpec{
-			RestartPolicy: v1.RestartPolicyNever,
+			RestartPolicy: v1.RestartPolicyAlways,
 			Containers: []v1.Container{
 				{
 					Name:      "scheduler",

--- a/go/tasks/plugins/k8s/dask/dask_test.go
+++ b/go/tasks/plugins/k8s/dask/dask_test.go
@@ -228,7 +228,7 @@ func TestBuildResourceDaskHappyPath(t *testing.T) {
 			Protocol:      "TCP",
 		},
 	}
-	assert.Equal(t, v1.RestartPolicyNever, schedulerSpec.RestartPolicy)
+	assert.Equal(t, v1.RestartPolicyAlways, schedulerSpec.RestartPolicy)
 	assert.Equal(t, defaultTestImage, schedulerSpec.Containers[0].Image)
 	assert.Equal(t, defaultResources, schedulerSpec.Containers[0].Resources)
 	assert.Equal(t, []string{"dask-scheduler"}, schedulerSpec.Containers[0].Args)


### PR DESCRIPTION
# TL;DR
In https://github.com/dask/dask-kubernetes/pull/711 `dask-kubernetes` switched to deploying the `scheduler` pod through a `Deployment` instead of a simple `PodSpec`. Within a `Deployment`, only `RestartPolicy: Always` is allowed and will lead to 
```
spec.template.spec.restartPolicy: Unsupported value: "Never": supported values: Always
```
otherwise.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
