### PR TITLE
Support gRPC config for agent-service plugin

### DIFF
--- a/go/tasks/plugins/webapi/agent/config.go
+++ b/go/tasks/plugins/webapi/agent/config.go
@@ -39,7 +39,7 @@ var (
 				Value: 50,
 			},
 		},
-		DefaultGrpcEndpoint: GrpcEndpoint{
+		DefaultAgent: Agent{
 			Endpoint:       "dns:///flyte-agent.flyte.svc.cluster.local:80",
 			Insecure:       true,
 			DefaultTimeout: config.Duration{Duration: 10 * time.Second},
@@ -58,21 +58,21 @@ type Config struct {
 	// ResourceConstraints defines resource constraints on how many executions to be created per project/overall at any given time
 	ResourceConstraints core.ResourceConstraintsSpec `json:"resourceConstraints" pflag:"-,Defines resource constraints on how many executions to be created per project/overall at any given time."`
 
-	// The default grpc endpoint if there does not exist a more specific matching against task types
-	DefaultGrpcEndpoint GrpcEndpoint `json:"defaultGrpcEndpoint" pflag:",The default grpc endpoint of agent service."`
+	// The default agent if there does not exist a more specific matching against task types
+	DefaultAgent Agent `json:"defaultAgent" pflag:",The default agent."`
 
-	// The grpc endpoints of agent services, which are used to match against specific task types
-	GrpcEndpoints map[string]*GrpcEndpoint `json:"grpcEndpoints" pflag:",The grpc endpoints of agent services."`
+	// The agents used to match against specific task types. {AgentId: Agent}
+	Agents map[string]*Agent `json:"agents" pflag:",The agents."`
 
-	// Maps endpoint to their plugin handler. {TaskType: Endpoint}
-	EndpointForTaskTypes map[string]string `json:"endpointForTaskTypes" pflag:"-,"`
+	// Maps task types to their agents. {TaskType: AgentId}
+	AgentForTaskTypes map[string]string `json:"agentForTaskTypes" pflag:"-,"`
 
 	// SupportedTaskTypes is a list of task types that are supported by this plugin.
 	SupportedTaskTypes []string `json:"supportedTaskTypes" pflag:"-,Defines a list of task types that are supported by this plugin."`
 }
 
-type GrpcEndpoint struct {
-	// Endpoint points to a gRPC service
+type Agent struct {
+	// Endpoint points to an agent gRPC endpoint
 	Endpoint string `json:"endpoint"`
 
 	// Insecure indicates whether the communication with the gRPC service is insecure

--- a/go/tasks/plugins/webapi/agent/config.go
+++ b/go/tasks/plugins/webapi/agent/config.go
@@ -10,8 +10,6 @@ import (
 )
 
 var (
-	defaultTimeout = config.Duration{Duration: 10 * time.Second}
-
 	defaultConfig = Config{
 		WebAPI: webapi.PluginConfig{
 			ResourceQuotas: map[core.ResourceNamespace]int{
@@ -42,8 +40,9 @@ var (
 			},
 		},
 		DefaultGrpcEndpoint: GrpcEndpoint{
-			Endpoint: "dns:///flyte-agent.flyte.svc.cluster.local:80",
-			Insecure: true,
+			Endpoint:       "dns:///flyte-agent.flyte.svc.cluster.local:80",
+			Insecure:       true,
+			DefaultTimeout: config.Duration{Duration: 10 * time.Second},
 		},
 		SupportedTaskTypes: []string{"task_type_1", "task_type_2"},
 	}
@@ -78,8 +77,11 @@ type GrpcEndpoint struct {
 	// DefaultServiceConfig sets default gRPC service config; check https://github.com/grpc/grpc/blob/master/doc/service_config.md for more details
 	DefaultServiceConfig string `json:"defaultServiceConfig"`
 
-	// Timeouts defines various RPC timeout values for different plugin operations: CreateTask, GetTask, DeleteTask; if not configured, defaults to 10s
+	// Timeouts defines various RPC timeout values for different plugin operations: CreateTask, GetTask, DeleteTask; if not configured, defaults to DefaultTimeout
 	Timeouts map[string]config.Duration `json:"timeouts"`
+
+	// DefaultTimeout gives the default RPC timeout if a more specific one is not defined in Timeouts
+	DefaultTimeout config.Duration `json:"defaultTimeout"`
 }
 
 func GetConfig() *Config {

--- a/go/tasks/plugins/webapi/agent/config.go
+++ b/go/tasks/plugins/webapi/agent/config.go
@@ -80,7 +80,7 @@ type GrpcEndpoint struct {
 	// Timeouts defines various RPC timeout values for different plugin operations: CreateTask, GetTask, DeleteTask; if not configured, defaults to DefaultTimeout
 	Timeouts map[string]config.Duration `json:"timeouts"`
 
-	// DefaultTimeout gives the default RPC timeout if a more specific one is not defined in Timeouts
+	// DefaultTimeout gives the default RPC timeout if a more specific one is not defined in Timeouts; if neither DefaultTimeout nor Timeouts is defined for an operation, RPC timeout will not be enforced
 	DefaultTimeout config.Duration `json:"defaultTimeout"`
 }
 

--- a/go/tasks/plugins/webapi/agent/config.go
+++ b/go/tasks/plugins/webapi/agent/config.go
@@ -58,10 +58,14 @@ type Config struct {
 	// ResourceConstraints defines resource constraints on how many executions to be created per project/overall at any given time
 	ResourceConstraints core.ResourceConstraintsSpec `json:"resourceConstraints" pflag:"-,Defines resource constraints on how many executions to be created per project/overall at any given time."`
 
+	// The default grpc endpoint if there does not exist a more specific matching against task types
 	DefaultGrpcEndpoint GrpcEndpoint `json:"defaultGrpcEndpoint" pflag:",The default grpc endpoint of agent service."`
 
+	// The grpc endpoints of agent services, which are used to match against specific task types
+	GrpcEndpoints map[string]*GrpcEndpoint `json:"grpcEndpoints" pflag:",The grpc endpoints of agent services."`
+
 	// Maps endpoint to their plugin handler. {TaskType: Endpoint}
-	EndpointForTaskTypes map[string]GrpcEndpoint `json:"endpointForTaskTypes" pflag:"-,"`
+	EndpointForTaskTypes map[string]string `json:"endpointForTaskTypes" pflag:"-,"`
 
 	// SupportedTaskTypes is a list of task types that are supported by this plugin.
 	SupportedTaskTypes []string `json:"supportedTaskTypes" pflag:"-,Defines a list of task types that are supported by this plugin."`

--- a/go/tasks/plugins/webapi/agent/config_test.go
+++ b/go/tasks/plugins/webapi/agent/config_test.go
@@ -27,6 +27,14 @@ func TestGetAndSetConfig(t *testing.T) {
 		},
 	}
 	cfg.DefaultGrpcEndpoint.DefaultTimeout = config.Duration{Duration: 10 * time.Second}
+	cfg.GrpcEndpoints = map[string]*GrpcEndpoint{
+		"endpoint_1": {
+			Insecure:             cfg.DefaultGrpcEndpoint.Insecure,
+			DefaultServiceConfig: cfg.DefaultGrpcEndpoint.DefaultServiceConfig,
+			Timeouts:             cfg.DefaultGrpcEndpoint.Timeouts,
+		},
+	}
+	cfg.EndpointForTaskTypes = map[string]string{"task_type_1": "endpoint_1"}
 	err := SetConfig(&cfg)
 	assert.NoError(t, err)
 	assert.Equal(t, &cfg, GetConfig())

--- a/go/tasks/plugins/webapi/agent/config_test.go
+++ b/go/tasks/plugins/webapi/agent/config_test.go
@@ -13,9 +13,9 @@ func TestGetAndSetConfig(t *testing.T) {
 	cfg := defaultConfig
 	cfg.WebAPI.Caching.Workers = 1
 	cfg.WebAPI.Caching.ResyncInterval.Duration = 5 * time.Second
-	cfg.DefaultGrpcEndpoint.Insecure = false
-	cfg.DefaultGrpcEndpoint.DefaultServiceConfig = "{\"loadBalancingConfig\": [{\"round_robin\":{}}]}"
-	cfg.DefaultGrpcEndpoint.Timeouts = map[string]config.Duration{
+	cfg.DefaultAgent.Insecure = false
+	cfg.DefaultAgent.DefaultServiceConfig = "{\"loadBalancingConfig\": [{\"round_robin\":{}}]}"
+	cfg.DefaultAgent.Timeouts = map[string]config.Duration{
 		"CreateTask": {
 			Duration: 1 * time.Millisecond,
 		},
@@ -26,15 +26,15 @@ func TestGetAndSetConfig(t *testing.T) {
 			Duration: 3 * time.Millisecond,
 		},
 	}
-	cfg.DefaultGrpcEndpoint.DefaultTimeout = config.Duration{Duration: 10 * time.Second}
-	cfg.GrpcEndpoints = map[string]*GrpcEndpoint{
+	cfg.DefaultAgent.DefaultTimeout = config.Duration{Duration: 10 * time.Second}
+	cfg.Agents = map[string]*Agent{
 		"endpoint_1": {
-			Insecure:             cfg.DefaultGrpcEndpoint.Insecure,
-			DefaultServiceConfig: cfg.DefaultGrpcEndpoint.DefaultServiceConfig,
-			Timeouts:             cfg.DefaultGrpcEndpoint.Timeouts,
+			Insecure:             cfg.DefaultAgent.Insecure,
+			DefaultServiceConfig: cfg.DefaultAgent.DefaultServiceConfig,
+			Timeouts:             cfg.DefaultAgent.Timeouts,
 		},
 	}
-	cfg.EndpointForTaskTypes = map[string]string{"task_type_1": "endpoint_1"}
+	cfg.AgentForTaskTypes = map[string]string{"task_type_1": "endpoint_1"}
 	err := SetConfig(&cfg)
 	assert.NoError(t, err)
 	assert.Equal(t, &cfg, GetConfig())

--- a/go/tasks/plugins/webapi/agent/config_test.go
+++ b/go/tasks/plugins/webapi/agent/config_test.go
@@ -26,6 +26,7 @@ func TestGetAndSetConfig(t *testing.T) {
 			Duration: 3 * time.Millisecond,
 		},
 	}
+	cfg.DefaultGrpcEndpoint.DefaultTimeout = config.Duration{Duration: 10 * time.Second}
 	err := SetConfig(&cfg)
 	assert.NoError(t, err)
 	assert.Equal(t, &cfg, GetConfig())

--- a/go/tasks/plugins/webapi/agent/config_test.go
+++ b/go/tasks/plugins/webapi/agent/config_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/flyteorg/flytestdlib/config"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -11,6 +13,19 @@ func TestGetAndSetConfig(t *testing.T) {
 	cfg := defaultConfig
 	cfg.WebAPI.Caching.Workers = 1
 	cfg.WebAPI.Caching.ResyncInterval.Duration = 5 * time.Second
+	cfg.DefaultGrpcEndpoint.Insecure = false
+	cfg.DefaultGrpcEndpoint.DefaultServiceConfig = "{\"loadBalancingConfig\": [{\"round_robin\":{}}]}"
+	cfg.DefaultGrpcEndpoint.Timeouts = map[string]config.Duration{
+		"CreateTask": {
+			Duration: 1 * time.Millisecond,
+		},
+		"GetTask": {
+			Duration: 2 * time.Millisecond,
+		},
+		"DeleteTask": {
+			Duration: 3 * time.Millisecond,
+		},
+	}
 	err := SetConfig(&cfg)
 	assert.NoError(t, err)
 	assert.Equal(t, &cfg, GetConfig())

--- a/go/tasks/plugins/webapi/agent/integration_test.go
+++ b/go/tasks/plugins/webapi/agent/integration_test.go
@@ -55,11 +55,11 @@ func (m *MockClient) DeleteTask(_ context.Context, _ *admin.DeleteTaskRequest, _
 	return &admin.DeleteTaskResponse{}, nil
 }
 
-func mockGetClientFunc(_ context.Context, _ GrpcEndpoint, _ map[string]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
+func mockGetClientFunc(_ context.Context, _ *GrpcEndpoint, _ map[*GrpcEndpoint]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
 	return &MockClient{}, nil
 }
 
-func mockGetBadClientFunc(_ context.Context, _ GrpcEndpoint, _ map[string]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
+func mockGetBadClientFunc(_ context.Context, _ *GrpcEndpoint, _ map[*GrpcEndpoint]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
 	return nil, fmt.Errorf("error")
 }
 

--- a/go/tasks/plugins/webapi/agent/integration_test.go
+++ b/go/tasks/plugins/webapi/agent/integration_test.go
@@ -55,11 +55,11 @@ func (m *MockClient) DeleteTask(_ context.Context, _ *admin.DeleteTaskRequest, _
 	return &admin.DeleteTaskResponse{}, nil
 }
 
-func mockGetClientFunc(_ context.Context, _ string, _ map[string]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
+func mockGetClientFunc(_ context.Context, _ GrpcEndpoint, _ map[string]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
 	return &MockClient{}, nil
 }
 
-func mockGetBadClientFunc(_ context.Context, _ string, _ map[string]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
+func mockGetBadClientFunc(_ context.Context, _ GrpcEndpoint, _ map[string]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
 	return nil, fmt.Errorf("error")
 }
 

--- a/go/tasks/plugins/webapi/agent/integration_test.go
+++ b/go/tasks/plugins/webapi/agent/integration_test.go
@@ -55,11 +55,11 @@ func (m *MockClient) DeleteTask(_ context.Context, _ *admin.DeleteTaskRequest, _
 	return &admin.DeleteTaskResponse{}, nil
 }
 
-func mockGetClientFunc(_ context.Context, _ *GrpcEndpoint, _ map[*GrpcEndpoint]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
+func mockGetClientFunc(_ context.Context, _ *Agent, _ map[*Agent]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
 	return &MockClient{}, nil
 }
 
-func mockGetBadClientFunc(_ context.Context, _ *GrpcEndpoint, _ map[*GrpcEndpoint]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
+func mockGetBadClientFunc(_ context.Context, _ *Agent, _ map[*Agent]*grpc.ClientConn) (service.AsyncAgentServiceClient, error) {
 	return nil, fmt.Errorf("error")
 }
 

--- a/go/tasks/plugins/webapi/agent/plugin_test.go
+++ b/go/tasks/plugins/webapi/agent/plugin_test.go
@@ -43,16 +43,16 @@ func TestPlugin(t *testing.T) {
 	t.Run("tet newAgentPlugin", func(t *testing.T) {
 		p := newAgentPlugin()
 		assert.NotNil(t, p)
-		assert.Equal(t, p.ID, "agent-service")
+		assert.Equal(t, "agent-service", p.ID)
 		assert.NotNil(t, p.PluginLoader)
 	})
 
 	t.Run("test getFinalEndpoint", func(t *testing.T) {
 		defaultGrpcEndpoint := GrpcEndpoint{Endpoint: "localhost:8080"}
 		endpoint := getFinalEndpoint("spark", defaultGrpcEndpoint, map[string]GrpcEndpoint{"spark": {Endpoint: "localhost:80"}})
-		assert.Equal(t, endpoint.Endpoint, "localhost:80")
+		assert.Equal(t, "localhost:80", endpoint.Endpoint)
 		endpoint = getFinalEndpoint("spark", defaultGrpcEndpoint, map[string]GrpcEndpoint{})
-		assert.Equal(t, endpoint.Endpoint, "localhost:8080")
+		assert.Equal(t, "localhost:8080", endpoint.Endpoint)
 	})
 
 	t.Run("test getClientFunc", func(t *testing.T) {
@@ -69,8 +69,16 @@ func TestPlugin(t *testing.T) {
 
 	t.Run("test getFinalTimeout", func(t *testing.T) {
 		timeout := getFinalTimeout("CreateTask", GrpcEndpoint{Endpoint: "localhost:8080", Timeouts: map[string]config.Duration{"CreateTask": {Duration: 1 * time.Millisecond}}})
-		assert.Equal(t, timeout.Duration, 1*time.Millisecond)
+		assert.Equal(t, 1*time.Millisecond, timeout.Duration)
 		timeout = getFinalTimeout("DeleteTask", GrpcEndpoint{Endpoint: "localhost:8080", DefaultTimeout: config.Duration{Duration: 10 * time.Second}})
-		assert.Equal(t, timeout.Duration, 10*time.Second)
+		assert.Equal(t, 10*time.Second, timeout.Duration)
+	})
+
+	t.Run("test getFinalContext", func(t *testing.T) {
+		ctx, _ := getFinalContext(context.TODO(), "DeleteTask", GrpcEndpoint{})
+		assert.Equal(t, context.TODO(), ctx)
+
+		ctx, _ = getFinalContext(context.TODO(), "CreateTask", GrpcEndpoint{Endpoint: "localhost:8080", Timeouts: map[string]config.Duration{"CreateTask": {Duration: 1 * time.Millisecond}}})
+		assert.NotEqual(t, context.TODO(), ctx)
 	})
 }

--- a/go/tasks/plugins/webapi/agent/plugin_test.go
+++ b/go/tasks/plugins/webapi/agent/plugin_test.go
@@ -68,9 +68,9 @@ func TestPlugin(t *testing.T) {
 	})
 
 	t.Run("test getFinalTimeout", func(t *testing.T) {
-		timeout := getFinalTimeout("CreateTask", map[string]config.Duration{"CreateTask": {Duration: 1 * time.Millisecond}})
+		timeout := getFinalTimeout("CreateTask", GrpcEndpoint{Endpoint: "localhost:8080", Timeouts: map[string]config.Duration{"CreateTask": {Duration: 1 * time.Millisecond}}})
 		assert.Equal(t, timeout.Duration, 1*time.Millisecond)
-		timeout = getFinalTimeout("DeleteTask", map[string]config.Duration{})
+		timeout = getFinalTimeout("DeleteTask", GrpcEndpoint{Endpoint: "localhost:8080", DefaultTimeout: config.Duration{Duration: 10 * time.Second}})
 		assert.Equal(t, timeout.Duration, 10*time.Second)
 	})
 }


### PR DESCRIPTION
# TL;DR
Support customized gRPC config for agent-service plugin.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [x] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

Support configuring gRPC endpoint with:

* insecure
* default service config
* timeouts

Details can be found in https://github.com/flyteorg/flyte/issues/3823

**Note that this is a breaking change!** I'm not sure how mature the `agent-service` is and how many users are using it, but if backward compatibility is important in this case, I can go an extra mile to achieve that.

## Tracking Issue
Closes https://github.com/flyteorg/flyte/issues/3823

## Follow-up issue
_NA_
