### PR TITLE
Fix deletion of elastic task resource requests

### DIFF
--- a/go/tasks/plugins/k8s/kfoperators/common/common_operator.go
+++ b/go/tasks/plugins/k8s/kfoperators/common/common_operator.go
@@ -268,12 +268,10 @@ func OverrideContainerSpec(podSpec *v1.PodSpec, containerName string, image stri
 				if len(resources.Requests) >= 1 || len(resources.Limits) >= 1 {
 					resources, err := flytek8s.ToK8sResourceRequirements(resources)
 					if err != nil {
-						return flyteerr.Errorf(flyteerr.BadTaskSpecification, "invalid TaskSpecificat ion on Resources [%v], Err: [%v]", resources, err.Error())
+						return flyteerr.Errorf(flyteerr.BadTaskSpecification, "invalid TaskSpecification on Resources [%v], Err: [%v]", resources, err.Error())
 					}
 					podSpec.Containers[idx].Resources = *resources
 				}
-			} else {
-				podSpec.Containers[idx].Resources = v1.ResourceRequirements{}
 			}
 			if len(args) != 0 {
 				podSpec.Containers[idx].Args = args

--- a/go/tasks/plugins/k8s/kfoperators/common/common_operator_test.go
+++ b/go/tasks/plugins/k8s/kfoperators/common/common_operator_test.go
@@ -314,11 +314,13 @@ func TestOverrideContainerSpecEmptyFields(t *testing.T) {
 
 func TestOverrideContainerNilResources(t *testing.T) {
 	podSpec := dummyPodSpec()
+	podSpecCopy := podSpec.DeepCopy()
+
 	err := OverrideContainerSpec(&podSpec, "primary container", "", nil, []string{})
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(podSpec.Containers))
-	assert.Nil(t, podSpec.Containers[0].Resources.Limits)
-	assert.Nil(t, podSpec.Containers[0].Resources.Requests)
+	assert.Equal(t, podSpec.Containers[0].Resources.Limits, podSpecCopy.Containers[0].Resources.Limits)
+	assert.Equal(t, podSpec.Containers[0].Resources.Requests, podSpecCopy.Containers[0].Resources.Requests)
 }
 
 func dummyTaskContext() pluginsCore.TaskExecutionContext {

--- a/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
+++ b/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch_test.go
@@ -720,7 +720,7 @@ func TestBuildResourcePytorchV1WithZeroWorker(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func TestParasElasticConfig(t *testing.T) {
+func TestParseElasticConfig(t *testing.T) {
 	elasticConfig := plugins.ElasticConfig{MinReplicas: 1, MaxReplicas: 2, NprocPerNode: 4, RdzvBackend: "c10d"}
 	elasticPolicy := ParseElasticConfig(&elasticConfig)
 	assert.Equal(t, int32(1), *elasticPolicy.MinReplicas)


### PR DESCRIPTION
# TL;DR

Currently, the following elastic task's pods **will not have any resource requests (1.8 release)**:

```python
@task(
    task_config=Elastic(
        nnodes=2,
        nproc_per_node=2,
    ),
    requests=Resources(cpu="1", mem="1Gi", gpu="1"),
)
def train():
    ...
```

This PR fixes this.


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description

The kubeflow plugin was recently refactored in flytekit (https://github.com/flyteorg/flytekit/pull/1627) as well as in flyteplugins (https://github.com/flyteorg/flyteplugins/pull/345).

After the refactoring, users can set e.g. different resources for master and worker replicas of `PyTorch` tasks:

```python
@task(
    task_config=PyTorch(
        worker=Worker(
            requests=Resources(cpu="2", mem="2Gi"),
            limits=Resources(cpu="4", mem="2Gi"),
        ),
        master=...
      )
      requests=Resources(cpu="1", mem="1Gi", gpu="1"),
)
....
```

If the user overrides one of the resource requests in the `task_config`, in the backend we override the resources configured on the task level [here](https://github.com/flyteorg/flyteplugins/blob/13ef7d6d6a178b06dffd592c4b49f46b9cda4410/go/tasks/plugins/k8s/kfoperators/common/common_operator.go#L260).

Now, in a `@task(task_config=PyTorch()..)` task, when the user *doesn't* override the resources, we send `task_models.Resources(requests=[], limits=[])` (which is different from `None/nil`, see [here](https://github.com/flyteorg/flytekit/blob/master/flytekit/core/resources.py#L78)) to the backend as part of the worker spec. We go into [this](https://github.com/flyteorg/flyteplugins/blob/13ef7d6d6a178b06dffd592c4b49f46b9cda4410/go/tasks/plugins/k8s/kfoperators/common/common_operator.go#L266) `if` statement but not into [this](https://github.com/flyteorg/flyteplugins/blob/13ef7d6d6a178b06dffd592c4b49f46b9cda4410/go/tasks/plugins/k8s/kfoperators/common/common_operator.go#L268) one within the first. As a consequence, in this case we *don't* overwrite the resource request set in `@task(requests=Resources())`. This makes sense.

However, the `Elastic` task config in `flytekitplugins` currently doesn't allow overwriting the resource request since elastic pytorch training jobs don't have a differentiation between master and worker replicas. There are only workers which means we can simply use the normal `@task(requests=Resources())` to specify their resources.

This, however, means that in this case we send `None/nil` to the backend as part of the worker specs resource request. [Here](https://github.com/flyteorg/flyteplugins/blob/13ef7d6d6a178b06dffd592c4b49f46b9cda4410/go/tasks/plugins/k8s/kfoperators/common/common_operator.go#L275) we go into the `else` case and simply delete what the user set as `@task(requests=Resources())`.

This seems wrong and this PR changes this.

## Tracking Issue
_NA_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
