### PR TITLE
Render task template in the agent client

### DIFF
--- a/go/tasks/plugins/webapi/agent/integration_test.go
+++ b/go/tasks/plugins/webapi/agent/integration_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/utils/strings/slices"
-
 	flyteIdlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	pluginCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	pluginCoreMocks "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/mocks"
@@ -32,6 +30,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/utils/strings/slices"
 )
 
 type MockPlugin struct {

--- a/go/tasks/plugins/webapi/agent/integration_test.go
+++ b/go/tasks/plugins/webapi/agent/integration_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/utils/strings/slices"
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"k8s.io/utils/strings/slices"
 
 	flyteIdlCore "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	pluginCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"

--- a/go/tasks/plugins/webapi/agent/integration_test.go
+++ b/go/tasks/plugins/webapi/agent/integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"k8s.io/utils/strings/slices"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -39,7 +40,11 @@ type MockPlugin struct {
 type MockClient struct {
 }
 
-func (m *MockClient) CreateTask(_ context.Context, _ *admin.CreateTaskRequest, _ ...grpc.CallOption) (*admin.CreateTaskResponse, error) {
+func (m *MockClient) CreateTask(_ context.Context, createTaskRequest *admin.CreateTaskRequest, _ ...grpc.CallOption) (*admin.CreateTaskResponse, error) {
+	expectedArgs := []string{"pyflyte-fast-execute", "--output-prefix", "fake://bucket/prefix/nhv"}
+	if slices.Equal(createTaskRequest.Template.GetContainer().Args, expectedArgs) {
+		return nil, fmt.Errorf("args not as expected")
+	}
 	return &admin.CreateTaskResponse{ResourceMeta: []byte{1, 2, 3, 4}}, nil
 }
 
@@ -95,6 +100,9 @@ func TestEndToEnd(t *testing.T) {
 	template := flyteIdlCore.TaskTemplate{
 		Type:   "bigquery_query_job_task",
 		Custom: st,
+		Target: &flyteIdlCore.TaskTemplate_Container{
+			Container: &flyteIdlCore.Container{Args: []string{"pyflyte-fast-execute", "--output-prefix", "{{.outputPrefix}}"}},
+		},
 	}
 	basePrefix := storage.DataReference("fake://bucket/prefix/")
 

--- a/go/tasks/plugins/webapi/agent/plugin.go
+++ b/go/tasks/plugins/webapi/agent/plugin.go
@@ -6,8 +6,6 @@ import (
 	"encoding/gob"
 	"fmt"
 
-	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/template"
-
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"github.com/flyteorg/flytestdlib/config"
 	"google.golang.org/grpc/credentials"
@@ -20,7 +18,7 @@ import (
 	pluginErrors "github.com/flyteorg/flyteplugins/go/tasks/errors"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
-	pluginsCore "github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/template"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi"
 	"github.com/flyteorg/flytestdlib/promutils"
@@ -69,13 +67,14 @@ func (p Plugin) Create(ctx context.Context, taskCtx webapi.TaskExecutionContextR
 	if err != nil {
 		return nil, nil, err
 	}
-	templateParameters := template.Parameters{
-		TaskExecMetadata: taskCtx.TaskExecutionMetadata(),
-		Inputs:           taskCtx.InputReader(),
-		OutputPath:       taskCtx.OutputWriter(),
-		Task:             taskCtx.TaskReader(),
-	}
+
 	if taskTemplate.GetContainer() != nil {
+		templateParameters := template.Parameters{
+			TaskExecMetadata: taskCtx.TaskExecutionMetadata(),
+			Inputs:           taskCtx.InputReader(),
+			OutputPath:       taskCtx.OutputWriter(),
+			Task:             taskCtx.TaskReader(),
+		}
 		modifiedArgs, err := template.Render(ctx, taskTemplate.GetContainer().Args, templateParameters)
 		if err != nil {
 			return nil, nil, err
@@ -164,7 +163,7 @@ func (p Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phase
 
 	switch resource.State {
 	case admin.State_RUNNING:
-		return core.PhaseInfoRunning(pluginsCore.DefaultPhaseVersion, taskInfo), nil
+		return core.PhaseInfoRunning(core.DefaultPhaseVersion, taskInfo), nil
 	case admin.State_PERMANENT_FAILURE:
 		return core.PhaseInfoFailure(pluginErrors.TaskFailedWithError, "failed to run the job", taskInfo), nil
 	case admin.State_RETRYABLE_FAILURE:
@@ -178,7 +177,7 @@ func (p Plugin) Status(ctx context.Context, taskCtx webapi.StatusContext) (phase
 		}
 		return core.PhaseInfoSuccess(taskInfo), nil
 	}
-	return core.PhaseInfoUndefined, pluginErrors.Errorf(pluginsCore.SystemErrorCode, "unknown execution phase [%v].", resource.State)
+	return core.PhaseInfoUndefined, pluginErrors.Errorf(core.SystemErrorCode, "unknown execution phase [%v].", resource.State)
 }
 
 func getFinalAgent(taskType string, cfg *Config) (*Agent, error) {
@@ -239,7 +238,7 @@ func getClientFunc(ctx context.Context, agent *Agent, connectionCache map[*Agent
 	return service.NewAsyncAgentServiceClient(conn), nil
 }
 
-func buildTaskExecutionMetadata(taskExecutionMetadata pluginsCore.TaskExecutionMetadata) admin.TaskExecutionMetadata {
+func buildTaskExecutionMetadata(taskExecutionMetadata core.TaskExecutionMetadata) admin.TaskExecutionMetadata {
 	taskExecutionID := taskExecutionMetadata.GetTaskExecutionID().GetID()
 	return admin.TaskExecutionMetadata{
 		TaskExecutionId:      &taskExecutionID,

--- a/go/tasks/plugins/webapi/agent/plugin.go
+++ b/go/tasks/plugins/webapi/agent/plugin.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/gob"
 	"fmt"
+
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/template"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"


### PR DESCRIPTION
# TL;DR
In some cases, people want to run `pyflyte-execute` command in the other container orchestrator platform instead of Kubernetes by using the agent. Therefore, we should render the command before sending the request to the agent.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Render the task template in the agent plugin

## Tracking Issue
_NA_

## Follow-up issue
_NA_