### PR TITLE
Expose NodeId as env var for kubernetes pods #minor

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/container_helper_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/container_helper_test.go
@@ -506,7 +506,7 @@ func TestAddFlyteCustomizationsToContainer(t *testing.T) {
 	assert.EqualValues(t, container.Command, []string{"s3://input/path"})
 	assert.Len(t, container.Resources.Limits, 3)
 	assert.Len(t, container.Resources.Requests, 3)
-	assert.Len(t, container.Env, 12)
+	assert.Len(t, container.Env, 13)
 }
 
 func TestAddFlyteCustomizationsToContainer_Resources(t *testing.T) {

--- a/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
+++ b/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
@@ -60,6 +60,10 @@ func GetExecutionEnvVars(id pluginsCore.TaskExecutionID) []v1.EnvVar {
 			Name:  "FLYTE_ATTEMPT_NUMBER",
 			Value: attemptNumber,
 		},
+		{
+			Name:  "FLYTE_INTERNAL_NODE_ID",
+			Value: id.GetID().NodeExecutionId.NodeId,
+		},
 		// TODO: Fill in these
 		// {
 		// 	Name:  "FLYTE_INTERNAL_EXECUTION_WORKFLOW",

--- a/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds_test.go
+++ b/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds_test.go
@@ -20,7 +20,7 @@ import (
 func TestGetExecutionEnvVars(t *testing.T) {
 	mock := mockTaskExecutionIdentifier{}
 	envVars := GetExecutionEnvVars(mock)
-	assert.Len(t, envVars, 12)
+	assert.Len(t, envVars, 13)
 }
 
 func TestGetTolerationsForResources(t *testing.T) {


### PR DESCRIPTION
# TL;DR
Exposes the NodeId to the kubernetes Pod as environment variable.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Currently the environment variables do not provide enough information to know the exact task being executed. 

For example we intended to create a unique ID for all retries of a task. Without the nodeID this is not possible as tasks might be reused. 

One can retrieve this information also from the hostname but this fails for long names due to k8s pod name length limits.
