### PR TITLE
Override Ray config with fields for namespace, service account, pod resources

### DIFF
--- a/go/tasks/plugins/k8s/ray/ray.go
+++ b/go/tasks/plugins/k8s/ray/ray.go
@@ -101,13 +101,6 @@ func (rayJobResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsC
 			return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "invalid TaskSpecification on Resources[%v], Err: [%v]", headGroupResources, err.Error())
 		}
 	}
-	workerGroupResources := &v1.ResourceRequirements{}
-	if rayJob.RayCluster.WorkerGroupSpec != nil {
-		workerGroupResources, err = flytek8s.ToK8sResourceRequirements(rayJob.RayCluster.WorkerGroupSpec[0].Resources)
-		if err != nil {
-			return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "invalid TaskSpecification on Resources[%v], Err: [%v]", workerGroupResources, err.Error())
-		}
-	}
 
 	enableIngress := true
 	rayClusterSpec := rayv1alpha1.RayClusterSpec{
@@ -122,6 +115,11 @@ func (rayJobResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsC
 	}
 
 	for _, spec := range rayJob.RayCluster.WorkerGroupSpec {
+		workerGroupResources, err := flytek8s.ToK8sResourceRequirements(spec.Resources)
+		if err != nil {
+			return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "invalid TaskSpecification on Resources[%v], Err: [%v]", workerGroupResources, err.Error())
+		}
+
 		workerPodTemplate := buildWorkerPodTemplate(&container, podSpec, objectMeta, taskCtx, workerGroupResources)
 
 		minReplicas := spec.Replicas

--- a/go/tasks/plugins/k8s/ray/ray.go
+++ b/go/tasks/plugins/k8s/ray/ray.go
@@ -90,10 +90,29 @@ func (rayJobResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsC
 		headNodeRayStartParams[DashboardHost] = GetConfig().DashboardHost
 	}
 
+	if rayJob.RayCluster.Namespace != "" {
+		objectMeta.Namespace = rayJob.RayCluster.Namespace
+	}
+
+	headGroupResources := &v1.ResourceRequirements{}
+	if rayJob.RayCluster.HeadGroupSpec != nil {
+		headGroupResources, err = flytek8s.ToK8sResourceRequirements(rayJob.RayCluster.HeadGroupSpec.Resources)
+		if err != nil {
+			return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "invalid TaskSpecification on Resources[%v], Err: [%v]", headGroupResources, err.Error())
+		}
+	}
+	workerGroupResources := &v1.ResourceRequirements{}
+	if rayJob.RayCluster.WorkerGroupSpec != nil {
+		workerGroupResources, err = flytek8s.ToK8sResourceRequirements(rayJob.RayCluster.WorkerGroupSpec[0].Resources)
+		if err != nil {
+			return nil, flyteerr.Errorf(flyteerr.BadTaskSpecification, "invalid TaskSpecification on Resources[%v], Err: [%v]", workerGroupResources, err.Error())
+		}
+	}
+
 	enableIngress := true
 	rayClusterSpec := rayv1alpha1.RayClusterSpec{
 		HeadGroupSpec: rayv1alpha1.HeadGroupSpec{
-			Template:       buildHeadPodTemplate(&container, podSpec, objectMeta, taskCtx),
+			Template:       buildHeadPodTemplate(&container, podSpec, objectMeta, taskCtx, headGroupResources),
 			ServiceType:    v1.ServiceType(GetConfig().ServiceType),
 			Replicas:       &headReplicas,
 			EnableIngress:  &enableIngress,
@@ -103,7 +122,7 @@ func (rayJobResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsC
 	}
 
 	for _, spec := range rayJob.RayCluster.WorkerGroupSpec {
-		workerPodTemplate := buildWorkerPodTemplate(&container, podSpec, objectMeta, taskCtx)
+		workerPodTemplate := buildWorkerPodTemplate(&container, podSpec, objectMeta, taskCtx, workerGroupResources)
 
 		minReplicas := spec.Replicas
 		maxReplicas := spec.Replicas
@@ -134,7 +153,10 @@ func (rayJobResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsC
 		rayClusterSpec.WorkerGroupSpecs = append(rayClusterSpec.WorkerGroupSpecs, workerNodeSpec)
 	}
 
-	serviceAccountName := flytek8s.GetServiceAccountNameFromTaskExecutionMetadata(taskCtx.TaskExecutionMetadata())
+	serviceAccountName := rayJob.RayCluster.K8SServiceAccount
+	if serviceAccountName == "" {
+		serviceAccountName = flytek8s.GetServiceAccountNameFromTaskExecutionMetadata(taskCtx.TaskExecutionMetadata())
+	}
 
 	rayClusterSpec.HeadGroupSpec.Template.Spec.ServiceAccountName = serviceAccountName
 	for index := range rayClusterSpec.WorkerGroupSpecs {
@@ -161,11 +183,15 @@ func (rayJobResourceHandler) BuildResource(ctx context.Context, taskCtx pluginsC
 	return &rayJobObject, nil
 }
 
-func buildHeadPodTemplate(container *v1.Container, podSpec *v1.PodSpec, objectMeta *metav1.ObjectMeta, taskCtx pluginsCore.TaskExecutionContext) v1.PodTemplateSpec {
+func buildHeadPodTemplate(container *v1.Container, podSpec *v1.PodSpec, objectMeta *metav1.ObjectMeta, taskCtx pluginsCore.TaskExecutionContext, resources *v1.ResourceRequirements) v1.PodTemplateSpec {
 	// Some configs are copy from  https://github.com/ray-project/kuberay/blob/b72e6bdcd9b8c77a9dc6b5da8560910f3a0c3ffd/apiserver/pkg/util/cluster.go#L97
 	// They should always be the same, so we could hard code here.
 	primaryContainer := container.DeepCopy()
 	primaryContainer.Name = "ray-head"
+
+	if len(resources.Requests) >= 1 || len(resources.Limits) >= 1 {
+		primaryContainer.Resources = *resources
+	}
 
 	envs := []v1.EnvVar{
 		{
@@ -212,7 +238,7 @@ func buildHeadPodTemplate(container *v1.Container, podSpec *v1.PodSpec, objectMe
 	return podTemplateSpec
 }
 
-func buildWorkerPodTemplate(container *v1.Container, podSpec *v1.PodSpec, objectMetadata *metav1.ObjectMeta, taskCtx pluginsCore.TaskExecutionContext) v1.PodTemplateSpec {
+func buildWorkerPodTemplate(container *v1.Container, podSpec *v1.PodSpec, objectMetadata *metav1.ObjectMeta, taskCtx pluginsCore.TaskExecutionContext, resources *v1.ResourceRequirements) v1.PodTemplateSpec {
 	// Some configs are copy from  https://github.com/ray-project/kuberay/blob/b72e6bdcd9b8c77a9dc6b5da8560910f3a0c3ffd/apiserver/pkg/util/cluster.go#L185
 	// They should always be the same, so we could hard code here.
 	initContainers := []v1.Container{
@@ -231,6 +257,10 @@ func buildWorkerPodTemplate(container *v1.Container, podSpec *v1.PodSpec, object
 	primaryContainer.Name = "ray-worker"
 
 	primaryContainer.Args = []string{}
+
+	if len(resources.Requests) >= 1 || len(resources.Limits) >= 1 {
+		primaryContainer.Resources = *resources
+	}
 
 	envs := []v1.EnvVar{
 		{


### PR DESCRIPTION
As per our conversation with the Union AI, we are making the following changes to the Ray plugin to enable more parameters to be configurable on the user side using flytekit SDK.

see:  https://github.com/flyteorg/flyteidl/pull/429

_- Use #patch, #minor or #major in the pull-request title to bump the corresponding version. Otherwise, the patch version
will be bumped. [More details](https://github.com/marketplace/actions/github-tag-bump)_

# TL;DR
_Please replace this text with a description of what this PR accomplishes._

## Type
 - [ ] Bug Fix
 - [x ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
_Remove the '*fixes*' keyword if there will be multiple PRs to fix the linked issue_

fixes https://github.com/flyteorg/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/flyteorg/flyte/issues/<number>_
