### PR TITLE
Feat: Expose nodeID to container

### DIFF
--- a/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
+++ b/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
@@ -31,6 +31,15 @@ func GetContextEnvVars(ownerCtx context.Context) []v1.EnvVar {
 			},
 		)
 	}
+
+	if nodeId := contextutils.Value(ownerCtx, contextutils.NodeIDKey); nodeId != "" {
+		envVars = append(envVars,
+			v1.EnvVar{
+				Name:  "FLYTE_INTERNAL_NODE_ID",
+				Value: nodeId,
+			},
+		)
+	}
 	return envVars
 }
 

--- a/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
+++ b/go/tasks/pluginmachinery/flytek8s/k8s_resource_adds.go
@@ -32,11 +32,11 @@ func GetContextEnvVars(ownerCtx context.Context) []v1.EnvVar {
 		)
 	}
 
-	if nodeId := contextutils.Value(ownerCtx, contextutils.NodeIDKey); nodeId != "" {
+	if nodeID := contextutils.Value(ownerCtx, contextutils.NodeIDKey); nodeID != "" {
 		envVars = append(envVars,
 			v1.EnvVar{
 				Name:  "FLYTE_INTERNAL_NODE_ID",
-				Value: nodeId,
+				Value: nodeID,
 			},
 		)
 	}


### PR DESCRIPTION
# TL;DR
Exposes the NodeId to the kubernetes Pod as environment variable.

```
- name: FLYTE_INTERNAL_NODE_ID
  value: n0/dn0/dn0/dn0/dn0/dn0/dn0/dn0/dn0/dn0
```

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Currently the environment variables do not provide enough information to know the exact task being executed. 

For example we intended to create a unique ID for all retries of a task. Without the nodeID this is not possible as tasks might be reused. 

One can retrieve this information also from the hostname but this fails for long names due to k8s pod name length limits.