### PR TITLE
Create a FileOutput reader if the agent produce file output

### DIFF
--- a/go/tasks/plugins/webapi/agent/integration_test.go
+++ b/go/tasks/plugins/webapi/agent/integration_test.go
@@ -108,9 +108,9 @@ func TestEndToEnd(t *testing.T) {
 		},
 	}
 	basePrefix := storage.DataReference("fake://bucket/prefix/")
-	pluginEntry := pluginmachinery.CreateRemotePlugin(newMockAgentPlugin())
 
 	t.Run("run a job", func(t *testing.T) {
+		pluginEntry := pluginmachinery.CreateRemotePlugin(newMockAgentPlugin())
 		plugin, err := pluginEntry.LoadPlugin(context.TODO(), newFakeSetupContext("test1"))
 		assert.NoError(t, err)
 
@@ -119,7 +119,8 @@ func TestEndToEnd(t *testing.T) {
 	})
 
 	t.Run("run a job that produces file output", func(t *testing.T) {
-		plugin, err := pluginEntry.LoadPlugin(context.TODO(), newFakeSetupContext("test1"))
+		pluginEntry := pluginmachinery.CreateRemotePlugin(newMockAgentPlugin())
+		plugin, err := pluginEntry.LoadPlugin(context.TODO(), newFakeSetupContext("test2"))
 		assert.NoError(t, err)
 
 		template.Type = "spark_job"

--- a/go/tasks/plugins/webapi/agent/integration_test.go
+++ b/go/tasks/plugins/webapi/agent/integration_test.go
@@ -108,9 +108,9 @@ func TestEndToEnd(t *testing.T) {
 		},
 	}
 	basePrefix := storage.DataReference("fake://bucket/prefix/")
+	pluginEntry := pluginmachinery.CreateRemotePlugin(newMockAgentPlugin())
 
 	t.Run("run a job", func(t *testing.T) {
-		pluginEntry := pluginmachinery.CreateRemotePlugin(newMockAgentPlugin())
 		plugin, err := pluginEntry.LoadPlugin(context.TODO(), newFakeSetupContext("test1"))
 		assert.NoError(t, err)
 
@@ -119,7 +119,6 @@ func TestEndToEnd(t *testing.T) {
 	})
 
 	t.Run("run a job that produces file output", func(t *testing.T) {
-		pluginEntry := pluginmachinery.CreateRemotePlugin(newMockAgentPlugin())
 		plugin, err := pluginEntry.LoadPlugin(context.TODO(), newFakeSetupContext("test1"))
 		assert.NoError(t, err)
 

--- a/go/tasks/plugins/webapi/agent/integration_test.go
+++ b/go/tasks/plugins/webapi/agent/integration_test.go
@@ -116,16 +116,11 @@ func TestEndToEnd(t *testing.T) {
 
 		phase := tests.RunPluginEndToEndTest(t, plugin, &template, inputs, nil, nil, iter)
 		assert.Equal(t, true, phase.Phase().IsSuccess())
-	})
-
-	t.Run("run a job that produces file output", func(t *testing.T) {
-		pluginEntry := pluginmachinery.CreateRemotePlugin(newMockAgentPlugin())
-		plugin, err := pluginEntry.LoadPlugin(context.TODO(), newFakeSetupContext("test2"))
-		assert.NoError(t, err)
 
 		template.Type = "spark_job"
-		phase := tests.RunPluginEndToEndTest(t, plugin, &template, inputs, nil, nil, iter)
+		phase = tests.RunPluginEndToEndTest(t, plugin, &template, inputs, nil, nil, iter)
 		assert.Equal(t, true, phase.Phase().IsSuccess())
+
 	})
 
 	t.Run("failed to create a job", func(t *testing.T) {

--- a/go/tasks/plugins/webapi/agent/integration_test.go
+++ b/go/tasks/plugins/webapi/agent/integration_test.go
@@ -118,7 +118,7 @@ func TestEndToEnd(t *testing.T) {
 		assert.Equal(t, true, phase.Phase().IsSuccess())
 	})
 
-	t.Run("run a job that doesn't produce any output", func(t *testing.T) {
+	t.Run("run a job that produces file output", func(t *testing.T) {
 		pluginEntry := pluginmachinery.CreateRemotePlugin(newMockAgentPlugin())
 		plugin, err := pluginEntry.LoadPlugin(context.TODO(), newFakeSetupContext("test1"))
 		assert.NoError(t, err)

--- a/go/tasks/plugins/webapi/agent/integration_test.go
+++ b/go/tasks/plugins/webapi/agent/integration_test.go
@@ -48,12 +48,15 @@ func (m *MockClient) CreateTask(_ context.Context, createTaskRequest *admin.Crea
 	return &admin.CreateTaskResponse{ResourceMeta: []byte{1, 2, 3, 4}}, nil
 }
 
-func (m *MockClient) GetTask(_ context.Context, _ *admin.GetTaskRequest, _ ...grpc.CallOption) (*admin.GetTaskResponse, error) {
-	return &admin.GetTaskResponse{Resource: &admin.Resource{State: admin.State_SUCCEEDED, Outputs: &flyteIdlCore.LiteralMap{
-		Literals: map[string]*flyteIdlCore.Literal{
-			"arr": coreutils.MustMakeLiteral([]interface{}{[]interface{}{"a", "b"}, []interface{}{1, 2}}),
-		},
-	}}}, nil
+func (m *MockClient) GetTask(_ context.Context, req *admin.GetTaskRequest, _ ...grpc.CallOption) (*admin.GetTaskResponse, error) {
+	if req.GetTaskType() == "bigquery_query_job_task" {
+		return &admin.GetTaskResponse{Resource: &admin.Resource{State: admin.State_SUCCEEDED, Outputs: &flyteIdlCore.LiteralMap{
+			Literals: map[string]*flyteIdlCore.Literal{
+				"arr": coreutils.MustMakeLiteral([]interface{}{[]interface{}{"a", "b"}, []interface{}{1, 2}}),
+			},
+		}}}, nil
+	}
+	return &admin.GetTaskResponse{Resource: &admin.Resource{State: admin.State_SUCCEEDED}}, nil
 }
 
 func (m *MockClient) DeleteTask(_ context.Context, _ *admin.DeleteTaskRequest, _ ...grpc.CallOption) (*admin.DeleteTaskResponse, error) {
@@ -111,6 +114,16 @@ func TestEndToEnd(t *testing.T) {
 		plugin, err := pluginEntry.LoadPlugin(context.TODO(), newFakeSetupContext("test1"))
 		assert.NoError(t, err)
 
+		phase := tests.RunPluginEndToEndTest(t, plugin, &template, inputs, nil, nil, iter)
+		assert.Equal(t, true, phase.Phase().IsSuccess())
+	})
+
+	t.Run("run a job that doesn't produce any output", func(t *testing.T) {
+		pluginEntry := pluginmachinery.CreateRemotePlugin(newMockAgentPlugin())
+		plugin, err := pluginEntry.LoadPlugin(context.TODO(), newFakeSetupContext("test1"))
+		assert.NoError(t, err)
+
+		template.Type = "spark_job"
 		phase := tests.RunPluginEndToEndTest(t, plugin, &template, inputs, nil, nil, iter)
 		assert.Equal(t, true, phase.Phase().IsSuccess())
 	})
@@ -251,7 +264,7 @@ func getTaskContext(t *testing.T) *pluginCoreMocks.TaskExecutionContext {
 func newMockAgentPlugin() webapi.PluginEntry {
 	return webapi.PluginEntry{
 		ID:                 "agent-service",
-		SupportedTaskTypes: []core.TaskType{"bigquery_query_job_task"},
+		SupportedTaskTypes: []core.TaskType{"bigquery_query_job_task", "spark_job"},
 		PluginLoader: func(ctx context.Context, iCtx webapi.PluginSetupContext) (webapi.AsyncPlugin, error) {
 			return &MockPlugin{
 				Plugin{

--- a/go/tasks/plugins/webapi/agent/plugin.go
+++ b/go/tasks/plugins/webapi/agent/plugin.go
@@ -6,11 +6,7 @@ import (
 	"encoding/gob"
 	"fmt"
 
-	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
-	"github.com/flyteorg/flytestdlib/logger"
-
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
-	"github.com/flyteorg/flytestdlib/config"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -22,8 +18,11 @@ import (
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/template"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi"
+	"github.com/flyteorg/flytestdlib/config"
+	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"google.golang.org/grpc"
 )

--- a/go/tasks/plugins/webapi/agent/plugin.go
+++ b/go/tasks/plugins/webapi/agent/plugin.go
@@ -188,7 +188,7 @@ func writeOutput(ctx context.Context, taskCtx webapi.StatusContext, resource *Re
 	}
 
 	if taskTemplate.Interface == nil || taskTemplate.Interface.Outputs == nil || taskTemplate.Interface.Outputs.Variables == nil {
-		logger.Infof(ctx, "The task declares no outputs. Skipping writing the outputs.")
+		logger.Debugf(ctx, "The task declares no outputs. Skipping writing the outputs.")
 		return nil
 	}
 

--- a/go/tasks/plugins/webapi/agent/plugin.go
+++ b/go/tasks/plugins/webapi/agent/plugin.go
@@ -194,10 +194,10 @@ func writeOutput(ctx context.Context, taskCtx webapi.StatusContext, resource *Re
 
 	var opReader io.OutputReader
 	if resource.Outputs != nil {
-		logger.Infof(ctx, "Agent returned an output")
+		logger.Debugf(ctx, "Agent returned an output")
 		opReader = ioutils.NewInMemoryOutputReader(resource.Outputs, nil, nil)
 	} else {
-		logger.Infof(ctx, "Agent didn't return any output, assuming file based outputs.")
+		logger.Debugf(ctx, "Agent didn't return any output, assuming file based outputs.")
 		opReader = ioutils.NewRemoteFileOutputReader(ctx, taskCtx.DataStore(), taskCtx.OutputWriter(), taskCtx.MaxDatasetSizeBytes())
 	}
 	return taskCtx.OutputWriter().Put(ctx, opReader)

--- a/go/tasks/plugins/webapi/agent/plugin_test.go
+++ b/go/tasks/plugins/webapi/agent/plugin_test.go
@@ -42,7 +42,7 @@ func TestPlugin(t *testing.T) {
 		assert.Equal(t, plugin.cfg.ResourceConstraints, constraints)
 	})
 
-	t.Run("tet newAgentPlugin", func(t *testing.T) {
+	t.Run("test newAgentPlugin", func(t *testing.T) {
 		p := newAgentPlugin()
 		assert.NotNil(t, p)
 		assert.Equal(t, "agent-service", p.ID)

--- a/tests/end_to_end.go
+++ b/tests/end_to_end.go
@@ -92,6 +92,7 @@ func RunPluginEndToEndTest(t *testing.T, executor pluginCore.Plugin, template *i
 	outputWriter.OnGetOutputPath().Return(basePrefix + "/outputs.pb")
 	outputWriter.OnGetCheckpointPrefix().Return("/checkpoint")
 	outputWriter.OnGetPreviousCheckpointsPrefix().Return("/prev")
+	outputWriter.OnPutMatch(mock.Anything, mock.Anything).Return(nil)
 
 	outputWriter.OnPutMatch(mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		or := args.Get(1).(io.OutputReader)


### PR DESCRIPTION
# TL;DR
Fixed https://flyte-org.slack.com/archives/C05GQ16TQLF/p1692227368597599

Create a `RemoteFileOutputReader` in the agent plugin if the task writes the output to the blob store.
For example, an agent may submit a job to aws batch, which will write the output to s3, so we should add a file output reader to task context.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
