### PR TITLE
Mark webapi task failure as retry limit exceeded

### DIFF
--- a/go/tasks/pluginmachinery/internal/webapi/cache.go
+++ b/go/tasks/pluginmachinery/internal/webapi/cache.go
@@ -78,20 +78,29 @@ func (q *ResourceCache) SyncResource(ctx context.Context, batch cache.Batch) (
 		logger.Debugf(ctx, "Sync loop - processing resource with cache key [%s]",
 			resource.GetID())
 
-		if cacheItem.SyncFailureCount > q.cfg.MaxSystemFailures {
-			logger.Infof(ctx, "Sync loop - Item with key [%v] has failed to sync [%v] time(s). More than the allowed [%v] time(s). Marking as failure.",
-				cacheItem.SyncFailureCount, q.cfg.MaxSystemFailures)
-			cacheItem.State.Phase = PhaseSystemFailure
-		}
-
 		if cacheItem.State.Phase.IsTerminal() {
-			logger.Debugf(ctx, "Sync loop - resource cache key [%v] in terminal state [%s]",
+			logger.Infof(ctx, "Sync loop - resource cache key [%v] in terminal state [%s]",
 				resource.GetID())
 
+			logger.Infof(ctx, "phase [%v]", cacheItem.Phase)
+			logger.Infof(ctx, "phase [%v]", resource.GetItem().(CacheItem).Phase)
 			resp = append(resp, cache.ItemSyncResponse{
 				ID:     resource.GetID(),
-				Item:   resource.GetItem(),
+				Item:   cacheItem,
 				Action: cache.Unchanged,
+			})
+
+			continue
+		}
+
+		if cacheItem.SyncFailureCount > q.cfg.MaxSystemFailures {
+			logger.Debugf(ctx, "Sync loop - Item with key [%v] has failed to sync [%v] time(s). More than the allowed [%v] time(s). Marking as failure.",
+				cacheItem.SyncFailureCount, q.cfg.MaxSystemFailures)
+			cacheItem.State.Phase = PhaseSystemFailure
+			resp = append(resp, cache.ItemSyncResponse{
+				ID:     resource.GetID(),
+				Item:   cacheItem,
+				Action: cache.Update,
 			})
 
 			continue
@@ -103,6 +112,7 @@ func (q *ResourceCache) SyncResource(ctx context.Context, batch cache.Batch) (
 		if err != nil {
 			logger.Infof(ctx, "Error retrieving resource [%s]. Error: %v", resource.GetID(), err)
 			cacheItem.SyncFailureCount++
+			cacheItem.ErrorMessage = err.Error()
 
 			// Make sure we don't return nil for the first argument, because that deletes it from the cache.
 			resp = append(resp, cache.ItemSyncResponse{

--- a/go/tasks/pluginmachinery/internal/webapi/cache.go
+++ b/go/tasks/pluginmachinery/internal/webapi/cache.go
@@ -79,11 +79,8 @@ func (q *ResourceCache) SyncResource(ctx context.Context, batch cache.Batch) (
 			resource.GetID())
 
 		if cacheItem.State.Phase.IsTerminal() {
-			logger.Infof(ctx, "Sync loop - resource cache key [%v] in terminal state [%s]",
+			logger.Debugf(ctx, "Sync loop - resource cache key [%v] in terminal state [%s]",
 				resource.GetID())
-
-			logger.Infof(ctx, "phase [%v]", cacheItem.Phase)
-			logger.Infof(ctx, "phase [%v]", resource.GetItem().(CacheItem).Phase)
 			resp = append(resp, cache.ItemSyncResponse{
 				ID:     resource.GetID(),
 				Item:   cacheItem,

--- a/go/tasks/pluginmachinery/internal/webapi/state.go
+++ b/go/tasks/pluginmachinery/internal/webapi/state.go
@@ -56,4 +56,7 @@ type State struct {
 
 	// The time the execution first requests for an allocation token
 	AllocationTokenRequestStartTime time.Time `json:"allocationTokenRequestStartTime,omitempty"`
+
+	// ErrorMessage generated during cache synchronization.
+	ErrorMessage string `json:"error_message,omitempty"`
 }

--- a/go/tasks/plugins/webapi/agent/plugin.go
+++ b/go/tasks/plugins/webapi/agent/plugin.go
@@ -5,11 +5,8 @@ import (
 	"crypto/x509"
 	"encoding/gob"
 	"fmt"
-	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
-	"github.com/flyteorg/flytestdlib/logger"
 
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
-	"github.com/flyteorg/flytestdlib/config"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
@@ -21,8 +18,11 @@ import (
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/core/template"
+	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/io"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/ioutils"
 	"github.com/flyteorg/flyteplugins/go/tasks/pluginmachinery/webapi"
+	"github.com/flyteorg/flytestdlib/config"
+	"github.com/flyteorg/flytestdlib/logger"
 	"github.com/flyteorg/flytestdlib/promutils"
 	"google.golang.org/grpc"
 )

--- a/go/tasks/plugins/webapi/agent/plugin.go
+++ b/go/tasks/plugins/webapi/agent/plugin.go
@@ -6,12 +6,11 @@ import (
 	"encoding/gob"
 	"fmt"
 
-	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-
 	"google.golang.org/grpc/grpclog"
 
+	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/admin"
 	flyteIdl "github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/core"
 	"github.com/flyteorg/flyteidl/gen/pb-go/flyteidl/service"
 	pluginErrors "github.com/flyteorg/flyteplugins/go/tasks/errors"


### PR DESCRIPTION
# TL;DR
fixed https://flyte-org.slack.com/archives/C05GQ16TQLF/p1692310075236329

propeller updates the `cache.state` to PhaseSystemFailure at [here](https://github.com/flyteorg/flyteplugins/blob/03f5b5c709277f49b04b65b591c469695defd8d4/go/tasks/pluginmachinery/internal/webapi/cache.go#L84). however, it sets the [action](https://github.com/flyteorg/flyteplugins/blob/03f5b5c709277f49b04b65b591c469695defd8d4/go/tasks/pluginmachinery/internal/webapi/cache.go#L94) to `cache.Unchanged` in `cache.ItemSyncResponse`, which won't update the item in the [LRU cache](https://github.com/flyteorg/flytestdlib/blob/dc81c279d511f271126443b2855843014727e34c/cache/auto_refresh.go#L288-L291).

Add an error message field to `cache.state`, and use it when we return `PhaseInfoFailure`. Therefore, we can see the error message on FlyteConsole if the propeller fails to get the task status.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
<img width="1523" alt="image" src="https://github.com/flyteorg/flyteplugins/assets/37936015/3988150f-277a-41de-9795-ba0bacbaff4d">


## Tracking Issue
_NA_

## Follow-up issue
_NA_
