### PR TITLE
Fix: Mounting of secrets in kfoperators #minor

### DIFF
--- a/go/tasks/plugins/k8s/kfoperators/mpi/mpi.go
+++ b/go/tasks/plugins/k8s/kfoperators/mpi/mpi.go
@@ -157,6 +157,12 @@ func (mpiOperatorResourceHandler) BuildResource(ctx context.Context, taskCtx plu
 		return nil, fmt.Errorf("number of launch worker should be more then 0")
 	}
 
+	errSecret := flytek8s.AppendSecretMountingMetadata(objectMeta, *taskTemplate)
+
+	if errSecret != nil {
+		return nil, errSecret
+	}
+
 	jobSpec := kubeflowv1.MPIJobSpec{
 		SlotsPerWorker: &slots,
 		RunPolicy:      runPolicy,

--- a/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
+++ b/go/tasks/plugins/k8s/kfoperators/pytorch/pytorch.go
@@ -148,6 +148,12 @@ func (pytorchOperatorResourceHandler) BuildResource(ctx context.Context, taskCtx
 		return nil, fmt.Errorf("number of worker should be more then 0")
 	}
 
+	errSecret := flytek8s.AppendSecretMountingMetadata(objectMeta, *taskTemplate)
+
+	if errSecret != nil {
+		return nil, errSecret
+	}
+
 	jobSpec := kubeflowv1.PyTorchJobSpec{
 		PyTorchReplicaSpecs: map[commonOp.ReplicaType]*commonOp.ReplicaSpec{
 			kubeflowv1.PyTorchJobReplicaTypeMaster: {

--- a/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
+++ b/go/tasks/plugins/k8s/kfoperators/tensorflow/tensorflow.go
@@ -163,6 +163,12 @@ func (tensorflowOperatorResourceHandler) BuildResource(ctx context.Context, task
 		return nil, fmt.Errorf("number of worker should be more then 0")
 	}
 
+	errSecret := flytek8s.AppendSecretMountingMetadata(objectMeta, *taskTemplate)
+
+	if errSecret != nil {
+		return nil, errSecret
+	}
+
 	jobSpec := kubeflowv1.TFJobSpec{
 		TFReplicaSpecs: map[commonOp.ReplicaType]*commonOp.ReplicaSpec{},
 	}


### PR DESCRIPTION
# TL;DR
First step to solve https://github.com/flyteorg/flyte/issues/3907 . It fixes the bug for kfoperator plugins and allows similar fixes for other k8s based plugins to mount secrets.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested: We tested it with `Elastic`, `Pytorch`, `Tensorflow`, `MPI` and `Horovod`
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Pods need specific labels and annotations that the mutating webhook picks them up and performs the mutations to mount the respective secrets. For plugins this did not work as these annotations were applied on the plugin object and not the `Pod` object (e.g. `PytorchJob` instead of `Pod`)

## Follow-up issue
https://github.com/flyteorg/flyte/issues/3907 still needs to be fixed for e.g. the `Dask` plugin