### PR TITLE
Fix resources requests for AWS Batch plugin

### DIFF
--- a/go/tasks/plugins/array/awsbatch/transformer.go
+++ b/go/tasks/plugins/array/awsbatch/transformer.go
@@ -88,11 +88,9 @@ func FlyteTaskToBatchInput(ctx context.Context, tCtx pluginCore.TaskExecutionCon
 		return nil, err
 	}
 
-
 	if overrideResources := tCtx.TaskExecutionMetadata().GetOverrides().GetResources(); overrideResources != nil {
 		flytek8s.MergeResources(*overrideResources, res)
 	}
-
 
 	platformResources := tCtx.TaskExecutionMetadata().GetPlatformResources()
 	if platformResources == nil {

--- a/go/tasks/plugins/array/awsbatch/transformer.go
+++ b/go/tasks/plugins/array/awsbatch/transformer.go
@@ -81,7 +81,19 @@ func FlyteTaskToBatchInput(ctx context.Context, tCtx pluginCore.TaskExecutionCon
 	}
 
 	envVars := getEnvVarsForTask(ctx, tCtx.TaskExecutionMetadata().GetTaskExecutionID(), taskTemplate.GetContainer().GetEnv(), cfg.DefaultEnvVars)
-	res := tCtx.TaskExecutionMetadata().GetOverrides().GetResources()
+
+	// compile resources
+	res, err := flytek8s.ToK8sResourceRequirements(taskTemplate.GetContainer().GetResources())
+	if err != nil {
+		return nil, err
+	}
+
+
+	if overrideResources := tCtx.TaskExecutionMetadata().GetOverrides().GetResources(); overrideResources != nil {
+		flytek8s.MergeResources(*overrideResources, res)
+	}
+
+
 	platformResources := tCtx.TaskExecutionMetadata().GetPlatformResources()
 	if platformResources == nil {
 		platformResources = &v1.ResourceRequirements{}


### PR DESCRIPTION
# TL;DR
This PR uses the container resources as the base before merging with resource overrides and platform defaults. The logic involved in [this PR](https://github.com/flyteorg/flytepropeller/pull/544) updated always setting the resource overrides even if there were none (if missing it would set overrides to the container resources), which introduced this regression.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flyte/issues/4003

## Follow-up issue
_NA_
