### PR TITLE
updating interruptibleFailureThreshold to int32 to allow negative values

### DIFF
--- a/go/tasks/pluginmachinery/core/exec_metadata.go
+++ b/go/tasks/pluginmachinery/core/exec_metadata.go
@@ -44,6 +44,6 @@ type TaskExecutionMetadata interface {
 	GetSecurityContext() core.SecurityContext
 	IsInterruptible() bool
 	GetPlatformResources() *v1.ResourceRequirements
-	GetInterruptibleFailureThreshold() uint32
+	GetInterruptibleFailureThreshold() int32
 	GetEnvironmentVariables() map[string]string
 }

--- a/go/tasks/pluginmachinery/core/mocks/task_execution_metadata.go
+++ b/go/tasks/pluginmachinery/core/mocks/task_execution_metadata.go
@@ -92,7 +92,7 @@ type TaskExecutionMetadata_GetInterruptibleFailureThreshold struct {
 	*mock.Call
 }
 
-func (_m TaskExecutionMetadata_GetInterruptibleFailureThreshold) Return(_a0 uint32) *TaskExecutionMetadata_GetInterruptibleFailureThreshold {
+func (_m TaskExecutionMetadata_GetInterruptibleFailureThreshold) Return(_a0 int32) *TaskExecutionMetadata_GetInterruptibleFailureThreshold {
 	return &TaskExecutionMetadata_GetInterruptibleFailureThreshold{Call: _m.Call.Return(_a0)}
 }
 
@@ -107,14 +107,14 @@ func (_m *TaskExecutionMetadata) OnGetInterruptibleFailureThresholdMatch(matcher
 }
 
 // GetInterruptibleFailureThreshold provides a mock function with given fields:
-func (_m *TaskExecutionMetadata) GetInterruptibleFailureThreshold() uint32 {
+func (_m *TaskExecutionMetadata) GetInterruptibleFailureThreshold() int32 {
 	ret := _m.Called()
 
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
+	var r0 int32
+	if rf, ok := ret.Get(0).(func() int32); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(uint32)
+		r0 = ret.Get(0).(int32)
 	}
 
 	return r0

--- a/go/tasks/plugins/array/k8s/subtask_exec_context.go
+++ b/go/tasks/plugins/array/k8s/subtask_exec_context.go
@@ -268,7 +268,7 @@ func NewSubTaskExecutionMetadata(taskExecutionMetadata pluginsCore.TaskExecution
 	}
 
 	subTaskExecutionID := NewSubTaskExecutionID(taskExecutionMetadata.GetTaskExecutionID(), executionIndex, retryAttempt)
-	interruptible := taskExecutionMetadata.IsInterruptible() && uint32(systemFailures) < taskExecutionMetadata.GetInterruptibleFailureThreshold()
+	interruptible := taskExecutionMetadata.IsInterruptible() && int32(systemFailures) < taskExecutionMetadata.GetInterruptibleFailureThreshold()
 	return SubTaskExecutionMetadata{
 		taskExecutionMetadata,
 		utils.UnionMaps(taskExecutionMetadata.GetAnnotations(), secretsMap),


### PR DESCRIPTION
# TL;DR
Allowing negative values to act as complementary. For example `-1` will allow all but the last attempt to be `interruptible`, `-2` means the last two, etc.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
https://github.com/flyteorg/flytepropeller/pull/596

## Follow-up issue
_NA_
