### PR TITLE
Revert "deprecated TransitionTypeBarrier (#336)"

### DIFF
--- a/go/tasks/pluginmachinery/core/transition.go
+++ b/go/tasks/pluginmachinery/core/transition.go
@@ -11,7 +11,6 @@ const (
 	// The transition is eventually consistent. For all the state written may not be visible in the next call, but eventually will persist
 	// Best to use when the plugin logic is completely idempotent. This is also the most performant option.
 	TransitionTypeEphemeral TransitionType = iota
-	// @deprecated support for Barrier type transitions has been deprecated
 	// This transition tries its best to make the latest state visible for every consecutive read. But, it is possible
 	// to go back in time, i.e. monotonic consistency is violated (in rare cases).
 	TransitionTypeBarrier

--- a/go/tasks/pluginmachinery/internal/webapi/core.go
+++ b/go/tasks/pluginmachinery/internal/webapi/core.go
@@ -97,7 +97,7 @@ func (c CorePlugin) Handle(ctx context.Context, tCtx core.TaskExecutionContext) 
 		return core.UnknownTransition, err
 	}
 
-	return core.DoTransition(phaseInfo), nil
+	return core.DoTransitionType(core.TransitionTypeBarrier, phaseInfo), nil
 }
 
 func (c CorePlugin) Abort(ctx context.Context, tCtx core.TaskExecutionContext) error {

--- a/go/tasks/plugins/array/k8s/executor.go
+++ b/go/tasks/plugins/array/k8s/executor.go
@@ -148,7 +148,7 @@ func (e Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		return core.UnknownTransition, err
 	}
 
-	return core.DoTransition(phaseInfo), nil
+	return core.DoTransitionType(core.TransitionTypeBarrier, phaseInfo), nil
 }
 
 func (e Executor) Abort(ctx context.Context, tCtx core.TaskExecutionContext) error {

--- a/go/tasks/plugins/hive/executor.go
+++ b/go/tasks/plugins/hive/executor.go
@@ -65,7 +65,7 @@ func (q QuboleHiveExecutor) Handle(ctx context.Context, tCtx core.TaskExecutionC
 		return core.UnknownTransition, err
 	}
 
-	return core.DoTransition(phaseInfo), nil
+	return core.DoTransitionType(core.TransitionTypeBarrier, phaseInfo), nil
 }
 
 func (q QuboleHiveExecutor) Abort(ctx context.Context, tCtx core.TaskExecutionContext) error {

--- a/go/tasks/plugins/presto/executor.go
+++ b/go/tasks/plugins/presto/executor.go
@@ -63,7 +63,7 @@ func (p Executor) Handle(ctx context.Context, tCtx core.TaskExecutionContext) (c
 		return core.UnknownTransition, err
 	}
 
-	return core.DoTransition(phaseInfo), nil
+	return core.DoTransitionType(core.TransitionTypeBarrier, phaseInfo), nil
 }
 
 func (p Executor) Abort(ctx context.Context, tCtx core.TaskExecutionContext) error {

--- a/tests/end_to_end.go
+++ b/tests/end_to_end.go
@@ -254,7 +254,7 @@ func RunPluginEndToEndTest(t *testing.T, executor pluginCore.Plugin, template *i
 	tCtx.OnMaxDatasetSizeBytes().Return(1000000)
 	tCtx.OnSecretManager().Return(secretManager)
 
-	trns := pluginCore.DoTransition(pluginCore.PhaseInfoQueued(time.Now(), 0, ""))
+	trns := pluginCore.DoTransitionType(pluginCore.TransitionTypeBarrier, pluginCore.PhaseInfoQueued(time.Now(), 0, ""))
 	for !trns.Info().Phase().IsTerminal() {
 		trns, err = executor.Handle(ctx, tCtx)
 		assert.NoError(t, err)


### PR DESCRIPTION
This reverts commit 4f02c2ca8d461538e43a1cd6250bcfd23cd448c4.

# TL;DR
Barriertick is required to ensure correct parallelism and node evaluation during DAG traversal.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
^^^

## Tracking Issue
_NA_

## Follow-up issue
_NA_
