### PR TITLE
Implement Spark pod template tolerations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -136,3 +136,5 @@ require (
 )
 
 replace github.com/aws/amazon-sagemaker-operator-for-k8s => github.com/aws/amazon-sagemaker-operator-for-k8s v1.0.1-0.20210303003444-0fb33b1fd49d
+
+replace github.com/flyteorg/flyteidl => /Users/andrew/dev/forks/flyteidl

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,6 @@ github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQL
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
-github.com/flyteorg/flyteidl v1.5.13 h1:IQ2Cw+u36ew3BPyRDAcHdzc/GyNEOXOxhKy9jbS4hbo=
-github.com/flyteorg/flyteidl v1.5.13/go.mod h1:EtE/muM2lHHgBabjYcxqe9TWeJSL0kXwbI0RgVwI4Og=
 github.com/flyteorg/flytestdlib v1.0.24 h1:jDvymcjlsTRCwOtxPapro0WZBe3isTz+T3Tiq+mZUuk=
 github.com/flyteorg/flytestdlib v1.0.24/go.mod h1:6nXa5g00qFIsgdvQ7jKQMJmDniqO0hG6Z5X5olfduqQ=
 github.com/flyteorg/stow v0.3.7 h1:Cx7j8/Ux6+toD5hp5fy++927V+yAcAttDeQAlUD/864=


### PR DESCRIPTION
# TL;DR
Populate driver and executor tolerations from optional pod templates. This is an initial step narrowly focused on pod tolerations, to be followed by a more generic solution that handles all pod template functionality.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This change builds on optional Spark pod template changes added in https://github.com/flyteorg/flyteidl/pull/450. For now appends tolerations from the driver and executor pod templates, if any, to the defaults used to build the SparkApplicationSpec. A follow up PR will refactor the Spark plugin and pod_helper.go to reuse [ToK8sPodSpec](https://github.com/flyteorg/flyteplugins/blob/6048689ca61f318ba30ac3e0df8729918314035e/go/tasks/pluginmachinery/flytek8s/pod_helper.go#L258) in order to consume other aspect of pod templates, as is done for other plugins.

## Tracking Issue
https://github.com/flyteorg/flyte/issues/4105
